### PR TITLE
Add {wait} opt to feed.get()

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Retrieve a block of data from the feed. If the block is not locally-available, t
 ``` js
 {
   verify: false // verify the data against the feed checksum, and fail the get() if !==
-  noWait: false // dont queue the download if not found, just repond with a notFound error
+  wait: true // queue the download if not found. If false, will just respond with a notFound error
 }
 ```
 

--- a/lib/feed.js
+++ b/lib/feed.js
@@ -179,7 +179,7 @@ Feed.prototype.get = function (block, opts, cb) { // TODO: on static feeds retur
   if (!this.opened) return this._openAndGet(block, cb)
 
   if (!this.bitfield.get(block)) {
-    if (opts.noWait) {
+    if (opts.wait === false) {
       // just error instead of queueing for the download
       var error = new Error('Block not found')
       error.notFound = true


### PR DESCRIPTION
This PR makes it possible to do `feed.get(block, {noWait: true}, ...)`. If the block isnt available, rather than queue it for download, it will callback immediately with a notFound error.

This is needed for https://github.com/joehand/hypercloud/issues/50