### PR TITLE
(draft) Add timeout option for core.get()

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -52,6 +52,10 @@ module.exports = class HypercoreError extends Error {
     return new HypercoreError(msg, 'REQUEST_CANCELLED', HypercoreError.REQUEST_CANCELLED)
   }
 
+  static REQUEST_TIMEOUT (msg = 'Request timed out') {
+    return new HypercoreError(msg, 'REQUEST_TIMEOUT', HypercoreError.REQUEST_TIMEOUT)
+  }
+
   static SESSION_NOT_WRITABLE (msg = 'Session is not writable') {
     return new HypercoreError(msg, 'SESSION_NOT_WRITABLE', HypercoreError.SESSION_NOT_WRITABLE)
   }

--- a/test/all.js
+++ b/test/all.js
@@ -28,6 +28,7 @@ async function runTests () {
   await import('./snapshots.js')
   await import('./storage.js')
   await import('./streams.js')
+  await import('./timeouts.js')
   await import('./user-data.js')
 
   test.resume()

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -1,0 +1,38 @@
+const test = require('brittle')
+const { create } = require('./helpers')
+const b4a = require('b4a')
+
+test('get before timeout', async function (t) {
+  t.plan(1)
+
+  const core = await create()
+
+  const req = core.get(0, { timeout: 500 })
+
+  req.then((block) => {
+    t.alike(block, b4a.from('hi'))
+  })
+
+  req.catch((err) => {
+    t.fail(err.message)
+  })
+
+  await core.append('hi')
+})
+
+test('get after timeout', async function (t) {
+  t.plan(1)
+
+  const core = await create()
+
+  const req = core.get(0, { timeout: 500 })
+
+  req.then((block) => {
+    console.log('block', block)
+    t.fail('should not have got block')
+  })
+
+  req.catch((err) => {
+    t.is(err.code, 'REQUEST_TIMEOUT')
+  })
+})


### PR DESCRIPTION
It currently has an issue: solo the second test, it passes but the process exits due the promise not being fully handled (I think it's the `await req` on `_cacheOnResolve`)