### PR TITLE
allow timeout=0, add catch to finally and check context presence

### DIFF
--- a/index.js
+++ b/index.js
@@ -750,12 +750,12 @@ module.exports = class Hypercore extends EventEmitter {
 
       block = this._cacheOnResolve(index, req.promise, this.core.tree.fork)
 
-      if (opts && opts.timeout) {
+      if (opts && opts.timeout != null) {
         const timeoutId = setTimeout(() => {
-          req.context.detach(req, REQUEST_TIMEOUT())
+          if (req.context) req.context.detach(req, REQUEST_TIMEOUT())
         }, opts.timeout)
 
-        req.promise.finally(() => clearTimeout(timeoutId))
+        req.promise.finally(() => clearTimeout(timeoutId)).catch(noop)
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -750,7 +750,7 @@ module.exports = class Hypercore extends EventEmitter {
 
       block = this._cacheOnResolve(index, req.promise, this.core.tree.fork)
 
-      if (opts && opts.timeout != null) {
+      if (opts && typeof opts.timeout === 'number') {
         const timeoutId = setTimeout(() => {
           if (req.context) req.context.detach(req, REQUEST_TIMEOUT())
         }, opts.timeout)

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -11,9 +11,7 @@ test('get before timeout', async function (t) {
 
   req.then((block) => {
     t.alike(block, b4a.from('hi'))
-  })
-
-  req.catch((err) => {
+  }).catch((err) => {
     t.fail(err.message)
   })
 
@@ -30,9 +28,22 @@ test('get after timeout', async function (t) {
   req.then((block) => {
     console.log('block', block)
     t.fail('should not have got block')
+  }).catch((err) => {
+    t.is(err.code, 'REQUEST_TIMEOUT')
   })
+})
 
-  req.catch((err) => {
+test('get after 0ms timeout', async function (t) {
+  t.plan(1)
+
+  const core = await create()
+
+  const req = core.get(0, { timeout: 0 })
+
+  req.then((block) => {
+    console.log('block', block)
+    t.fail('should not have got block')
+  }).catch((err) => {
     t.is(err.code, 'REQUEST_TIMEOUT')
   })
 })

--- a/test/timeouts.js
+++ b/test/timeouts.js
@@ -9,11 +9,14 @@ test('get before timeout', async function (t) {
 
   const req = core.get(0, { timeout: 500 })
 
-  req.then((block) => {
-    t.alike(block, b4a.from('hi'))
-  }).catch((err) => {
-    t.fail(err.message)
-  })
+  req.then(
+    (block) => {
+      t.alike(block, b4a.from('hi'))
+    },
+    (err) => {
+      t.fail(err.message)
+    }
+  )
 
   await core.append('hi')
 })
@@ -25,12 +28,15 @@ test('get after timeout', async function (t) {
 
   const req = core.get(0, { timeout: 500 })
 
-  req.then((block) => {
-    console.log('block', block)
-    t.fail('should not have got block')
-  }).catch((err) => {
-    t.is(err.code, 'REQUEST_TIMEOUT')
-  })
+  req.then(
+    (block) => {
+      console.log('block', block)
+      t.fail('should not have got block')
+    },
+    (err) => {
+      t.is(err.code, 'REQUEST_TIMEOUT')
+    }
+  )
 })
 
 test('get after 0ms timeout', async function (t) {
@@ -40,10 +46,13 @@ test('get after 0ms timeout', async function (t) {
 
   const req = core.get(0, { timeout: 0 })
 
-  req.then((block) => {
-    console.log('block', block)
-    t.fail('should not have got block')
-  }).catch((err) => {
-    t.is(err.code, 'REQUEST_TIMEOUT')
-  })
+  req.then(
+    (block) => {
+      console.log('block', block)
+      t.fail('should not have got block')
+    },
+    (err) => {
+      t.is(err.code, 'REQUEST_TIMEOUT')
+    }
+  )
 })


### PR DESCRIPTION
I think there were some promise handlers without catch-logic, and that those resulted in the uncaught exception error.

In particular:
-`req.promise.finally` returns a rejected promise if `req.promise` is rejected, so I think it needs to be handled there too (as in: explicitly ignore)
- In the tests, the get(...) path didn't have a catch, so if the promise rejects, this path was also unhandled

Minor things:
- Allowing 0ms timeout (the code was assuming timeout=0 => no timeout, which I don't think is intended)
- I'm not entirely sure, but I think there is a particular flow where req.context is null when setTimeout's method is called, if req.promise resolves in the same cycle as the timeout is triggered. Just in case, I added the check on req.context
