### PR TITLE
Flush Merkle Tree Nodes to Storage in Contiguous Batches

### DIFF
--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -476,10 +476,10 @@ module.exports = class MerkleTree {
       let error = null
       let missing = 1
       let offset = 0
-      let ridx = -1
+      let rindex = -1
 
       const indexes = Array.from(this.flushing.keys()).sort((x, y) => x - y)
-      const rngs = []
+      const ranges = []
 
       // build continuous ranges
       for (const index of indexes) {
@@ -494,18 +494,18 @@ module.exports = class MerkleTree {
         c.uint64.encode(state, node.size)
         c.raw.encode(state, node.hash)
 
-        const rng = rngs[ridx]
-        if (rng && (rng.max + 1) === index) rng.max = index
-        else rngs[++ridx] = { min: index, max: index, offset: offset - 40 }
+        const range = ranges[rindex]
+        if (range && (range.max + 1) === index) range.max = index
+        else ranges[++rindex] = { min: index, max: index, offset: offset - 40 }
       }
 
-      missing += rngs.length
+      missing += ranges.length
 
       // write ranges to disk
-      for (const rng of rngs) {
-        const len = ++rng.max - rng.min
-        const buf = slab.slice(rng.offset, rng.offset + (40 * len))
-        this.storage.write(rng.min * 40, buf, done)
+      for (const range of ranges) {
+        const len = ++range.max - range.min
+        const buf = slab.slice(range.offset, range.offset + (40 * len))
+        this.storage.write(range.min * 40, buf, done)
       }
 
       done(null)

--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -469,16 +469,22 @@ module.exports = class MerkleTree {
   }
 
   _flushNodes () {
-    // TODO: write neighbors together etc etc
     // TODO: bench loading a full disk page and copy to that instead
     return new Promise((resolve, reject) => {
       const slab = b4a.allocUnsafe(40 * this.flushing.size)
 
       let error = null
-      let missing = this.flushing.size + 1
+      let missing = 1
       let offset = 0
+      let ridx = -1
 
-      for (const node of this.flushing.values()) {
+      const indexes = Array.from(this.flushing.keys()).sort((x, y) => x - y)
+      const rngs = []
+
+      // build continuous ranges
+      for (const index of indexes) {
+        const node = this.flushing.get(index)
+
         const state = {
           start: 0,
           end: 40,
@@ -488,7 +494,18 @@ module.exports = class MerkleTree {
         c.uint64.encode(state, node.size)
         c.raw.encode(state, node.hash)
 
-        this.storage.write(node.index * 40, state.buffer, done)
+        const rng = rngs[ridx]
+        if (rng && (rng.max + 1) === index) rng.max = index
+        else rngs[++ridx] = { min: index, max: index, offset: offset - 40 }
+      }
+
+      missing += rngs.length
+
+      // write ranges to disk
+      for (const rng of rngs) {
+        const len = ++rng.max - rng.min
+        const buf = slab.slice(rng.offset, rng.offset + (40 * len))
+        this.storage.write(rng.min * 40, buf, done)
       }
 
       done(null)

--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -468,6 +468,13 @@ module.exports = class MerkleTree {
     })
   }
 
+  _flushRange (slab, range, cb) {
+    if (!range) return cb(null)
+    const len = ++range.max - range.min
+    const buf = slab.subarray(range.offset, range.offset + (40 * len))
+    this.storage.write(range.min * 40, buf, cb)
+  }
+
   _flushNodes () {
     // TODO: bench loading a full disk page and copy to that instead
     return new Promise((resolve, reject) => {
@@ -476,14 +483,14 @@ module.exports = class MerkleTree {
       let error = null
       let missing = 1
       let offset = 0
-      let rindex = -1
+      let range = null
 
       const indexes = Array.from(this.flushing.keys()).sort((x, y) => x - y)
-      const ranges = []
 
       // build continuous ranges
       for (const index of indexes) {
         const node = this.flushing.get(index)
+        const prev = offset
 
         const state = {
           start: 0,
@@ -494,20 +501,18 @@ module.exports = class MerkleTree {
         c.uint64.encode(state, node.size)
         c.raw.encode(state, node.hash)
 
-        const range = ranges[rindex]
-        if (range && (range.max + 1) === index) range.max = index
-        else ranges[++rindex] = { min: index, max: index, offset: offset - 40 }
+        if (range && (range.max + 1) === index) {
+          range.max = index
+          continue
+        }
+
+        missing++
+        this._flushRange(slab, range, done)
+        range = { min: index, max: index, offset: prev }
       }
 
-      missing += ranges.length
-
-      // write ranges to disk
-      for (const range of ranges) {
-        const len = ++range.max - range.min
-        const buf = slab.slice(range.offset, range.offset + (40 * len))
-        this.storage.write(range.min * 40, buf, done)
-      }
-
+      missing++
+      this._flushRange(slab, range, done)
       done(null)
 
       function done (err) {


### PR DESCRIPTION
I was appending some moderately sized real time media to hypercore in batches, and hit a consistent >1000ms bottleneck flushing merkle nodes to storage per batch. This PR adds logic to flush nodes to disk in batches of contiguous indexes. For my use case it dropped avg latency to <100ms per batch. 

- [x] passes unit tests