### PR TITLE
enables firewalling replication on a per-peer basis

### DIFF
--- a/index.js
+++ b/index.js
@@ -439,26 +439,26 @@ module.exports = class Hypercore extends EventEmitter {
     const protocolStream = Hypercore.createProtocolStream(isInitiator, opts)
     const noiseStream = protocolStream.noiseStream
     const protocol = noiseStream.userData
-    const useSession = !!opts.session
 
-    this._attachToMuxer(protocol, useSession, opts)
+    this._attachToMuxer(protocol, opts)
 
     return protocolStream
   }
 
-  _attachToMuxer (mux, useSession, opts) {
+  _attachToMuxer (mux, opts = {}) {
     if (this.opened) {
-      this._attachToMuxerOpened(mux, useSession, opts)
+      this._attachToMuxerOpened(mux, opts)
     } else {
-      this.opening.then(this._attachToMuxerOpened.bind(this, mux, useSession, opts), mux.destroy.bind(mux))
+      this.opening.then(this._attachToMuxerOpened.bind(this, mux, opts), mux.destroy.bind(mux))
     }
 
     return mux
   }
 
-  _attachToMuxerOpened (mux, useSession, opts = {}) {
+  _attachToMuxerOpened (mux, opts = {}) {
     // If the user wants to, we can make this replication run in a session
     // that way the core wont close "under them" during replication
+    const useSession = !!opts.session
 
     const maybeAttach = (allow) => {
       if (!allow) return mux.destroy()

--- a/index.js
+++ b/index.js
@@ -434,7 +434,7 @@ module.exports = class Hypercore extends EventEmitter {
     opts = { firewall: this.firewall, ...opts }
     // Only limitation here is that ondiscoverykey doesn't work atm when passing a muxer directly,
     // because it doesn't really make a lot of sense.
-    if (Protomux.isProtomux(isInitiator)) return this._attachToMuxer(isInitiator, true, opts)
+    if (Protomux.isProtomux(isInitiator)) return this._attachToMuxer(isInitiator, { session: true, ...opts })
 
     const protocolStream = Hypercore.createProtocolStream(isInitiator, opts)
     const noiseStream = protocolStream.noiseStream

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
   },
   "devDependencies": {
     "brittle": "^3.0.0",
+    "duplex-through": "^1.0.2",
     "hyperswarm": "^4.3.6",
     "random-access-memory": "^6.1.0",
     "random-access-memory-overlay": "^3.0.0",

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -1073,13 +1073,14 @@ test('firewall peers - at .replicate()', async function (t) {
     function onclose () { if (--missing === 0) resolve() }
   })
 
-  const firewall = async (rpk) => !b4a.compare(rpk, keys[1].publicKey)
+  const firewall = async (rpk) => b4a.compare(rpk, keys[1].publicKey)
+  const onfirewalled = (mux) => mux.destroy()
 
   await a.append(['a'])
 
-  a.replicate(p1[0], { keepAlive: false, firewall })
+  a.replicate(p1[0], { keepAlive: false, firewall, onfirewalled })
   b.replicate(p1[1], { keepAlive: false })
-  a.replicate(p2[0], { keepAlive: false, firewall })
+  a.replicate(p2[0], { keepAlive: false, firewall, onfirewalled })
   c.replicate(p2[1], { keepAlive: false })
 
   t.is(b4a.toString(await b.get(0), 'utf8'), 'a')
@@ -1090,9 +1091,10 @@ test('firewall peers - at .replicate()', async function (t) {
 
 test('firewall peers - at constructor', async function (t) {
   const keys = [NoiseSecretStream.keyPair(), NoiseSecretStream.keyPair(), NoiseSecretStream.keyPair()]
-  const firewall = async (rpk) => !b4a.compare(rpk, keys[1].publicKey)
+  const firewall = async (rpk) => b4a.compare(rpk, keys[1].publicKey)
+  const onfirewalled = (mux) => mux.destroy()
 
-  const a = await create({ firewall })
+  const a = await create({ firewall, onfirewalled })
   const b = await create(a.key)
   const c = await create(a.key)
 


### PR DESCRIPTION
This pull request captures the work required to firewall peers on replication, effectively re-implements https://github.com/holepunchto/hypercore/pull/291 for v10.

It works by:

1. waiting for the noiseStream to connect
2. authenticating the peer
3. attaching the mux and session to the replicator

This allows for finer-grained firewalling of individual hypercores, it mirrors the [hyperdht](https://github.com/holepunchto/hyperdht#const-server--nodecreateserveroptions-onconnection) firewall api.

### open questions
- [x] Does mux need to be corked before and uncorked after firewalling? No.
- [ ] Is this the right api? 

### open work
- [ ] update the README if the api looks right
- [ ] update Corestore to support a firewall option