### PR TITLE
Always set passed key sync

### DIFF
--- a/index.js
+++ b/index.js
@@ -27,10 +27,10 @@ module.exports = class Hypercore extends EventEmitter {
     if (isOptions(storage)) {
       opts = storage
       storage = null
-      key = null
+      key = opts.key || null
     } else if (isOptions(key)) {
       opts = key
-      key = null
+      key = opts.key || null
     }
 
     if (key && typeof key === 'string') {

--- a/test/basic.js
+++ b/test/basic.js
@@ -1,5 +1,6 @@
 const test = require('brittle')
 const RAM = require('random-access-memory')
+const b4a = require('b4a')
 
 const Hypercore = require('../')
 const { create, eventFlush } = require('./helpers')
@@ -324,4 +325,17 @@ test('indexedLength mirrors core length (linearised core compat)', async functio
   await core.append(['a', 'b'])
   t.is(core.length, 2)
   t.is(core.indexedLength, core.length)
+})
+
+test('key is set sync', async function (t) {
+  const key = b4a.from('a'.repeat(64), 'hex')
+
+  t.alike((new Hypercore(RAM, key)).key, key)
+  t.is((new Hypercore(RAM)).key, null)
+
+  t.alike((new Hypercore(RAM, { key })).key, key)
+  t.is((new Hypercore(RAM, { })).key, null)
+
+  t.alike((new Hypercore({ key })).key, key)
+  t.is((new Hypercore({ })).key, null)
 })


### PR DESCRIPTION
Also set key sync when passed as an opt (for example when creating through `corestore.get(...)`

Note: probably also sensible to do the same with storage in a follow-up PR