### PR TITLE
Allow rmdir opt for defaultStorage()

### DIFF
--- a/index.js
+++ b/index.js
@@ -173,13 +173,14 @@ module.exports = class Hypercore extends EventEmitter {
     const directory = storage
     const toLock = opts.unlocked ? null : (opts.lock || 'oplog')
     const pool = opts.pool || (opts.poolSize ? RAF.createPool(opts.poolSize) : null)
+    const rmdir = !!opts.rmdir
 
     return createFile
 
     function createFile (name) {
       const lock = toLock === null ? false : isFile(name, toLock)
       const sparse = isFile(name, 'data') || isFile(name, 'bitfield') || isFile(name, 'tree')
-      return new RAF(name, { directory, lock, sparse, pool: lock ? null : pool })
+      return new RAF(name, { directory, lock, sparse, pool: lock ? null : pool, rmdir })
     }
 
     function isFile (name, n) {


### PR DESCRIPTION
Needed to cleanly support hypercore.purge() for corestore-created Hypercores, because it then also removes the intermediary dirs created, like `ab` and `cd` in `corestoreLoc/cores/ab/cd/abcd12...`)

Note: this is a conservative approach, because it does not set rmdir true by default, but I think that removing the opt and always setting `rmdir: true` for a RAF-based storage might also be fine.