### PR TITLE
Use RAM in test: clear blocks with diff option

### DIFF
--- a/test/clear.js
+++ b/test/clear.js
@@ -3,7 +3,7 @@ const b4a = require('b4a')
 const RAM = require('random-access-memory')
 const { create, replicate, eventFlush } = require('./helpers')
 
-const Hypercore = require('../index.js')
+const Hypercore = require('../')
 
 test('clear', async function (t) {
   const a = await create()

--- a/test/clear.js
+++ b/test/clear.js
@@ -1,8 +1,6 @@
 const test = require('brittle')
 const b4a = require('b4a')
-const { create, replicate, eventFlush, createTmpDir } = require('./helpers')
-
-const Hypercore = require('../')
+const { create, replicate, eventFlush } = require('./helpers')
 
 test('clear', async function (t) {
   const a = await create()
@@ -81,10 +79,8 @@ test('incorrect clear', async function (t) {
 })
 
 test('clear blocks with diff option', async function (t) {
-  const storage = createTmpDir(t)
-
-  const core = new Hypercore(storage)
-  await core.append(b4a.alloc(4 * 1024))
+  const core = await create()
+  await core.append(b4a.alloc(1024 * 1024))
 
   const cleared = await core.clear(1337)
   t.is(cleared, null)

--- a/test/clear.js
+++ b/test/clear.js
@@ -1,6 +1,9 @@
 const test = require('brittle')
 const b4a = require('b4a')
+const RAM = require('random-access-memory')
 const { create, replicate, eventFlush } = require('./helpers')
+
+const Hypercore = require('../index.js')
 
 test('clear', async function (t) {
   const a = await create()
@@ -79,8 +82,8 @@ test('incorrect clear', async function (t) {
 })
 
 test('clear blocks with diff option', async function (t) {
-  const core = await create()
-  await core.append(b4a.alloc(1024 * 1024))
+  const core = new Hypercore(() => new RAM({ pageSize: 128 }))
+  await core.append(b4a.alloc(128))
 
   const cleared = await core.clear(1337)
   t.is(cleared, null)


### PR DESCRIPTION
I thought it wasn't possible for it to return cleared bytes using RAM but seems possible by using a bigger buffer