### PR TITLE
Make Hypercore errors a public export

### DIFF
--- a/errors.js
+++ b/errors.js
@@ -1,0 +1,1 @@
+module.exports = require('./lib/errors')

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -44,7 +44,7 @@ module.exports = class HypercoreError extends Error {
     return new HypercoreError(msg, 'INVALID_PROOF', HypercoreError.INVALID_PROOF)
   }
 
-  static BLOCK_NOT_AVAILABLE (msg = 'Snapshot is not available') {
+  static BLOCK_NOT_AVAILABLE (msg = 'Block is not available') {
     return new HypercoreError(msg, 'BLOCK_NOT_AVAILABLE', HypercoreError.BLOCK_NOT_AVAILABLE)
   }
 

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -44,6 +44,10 @@ module.exports = class HypercoreError extends Error {
     return new HypercoreError(msg, 'INVALID_PROOF', HypercoreError.INVALID_PROOF)
   }
 
+  static BLOCK_NOT_AVAILABLE (msg = 'Snapshot is not available') {
+    return new HypercoreError(msg, 'BLOCK_NOT_AVAILABLE', HypercoreError.BLOCK_NOT_AVAILABLE)
+  }
+
   static SNAPSHOT_NOT_AVAILABLE (msg = 'Snapshot is not available') {
     return new HypercoreError(msg, 'SNAPSHOT_NOT_AVAILABLE', HypercoreError.SNAPSHOT_NOT_AVAILABLE)
   }


### PR DESCRIPTION
This PR allows users to import hypercore errors as `require('hypercore/errors')`.

This is useful to throw from dependent modules such as Hyperbee and Autobase.