### PR TITLE
Byte stream should force binary encoding when 'valueEncoding' is set …

### DIFF
--- a/lib/streams.js
+++ b/lib/streams.js
@@ -105,7 +105,7 @@ class ByteStream extends Readable {
     }
 
     this._predownload(this._index + 1)
-    data = await this._core.get(this._index++, {valueEncoding: "binary"});
+    data = await this._core.get(this._index++, { valueEncoding: 'binary' })
 
     if (relativeOffset > 0) data = data.subarray(relativeOffset)
 

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -105,7 +105,7 @@ class ByteStream extends Readable {
     }
 
     this._predownload(this._index + 1)
-    data = await this._core.get(this._index++)
+    data = await this._core.get(this._index++, {valueEncoding: "binary"});
 
     if (relativeOffset > 0) data = data.subarray(relativeOffset)
 

--- a/test/streams.js
+++ b/test/streams.js
@@ -121,6 +121,30 @@ test('basic byte stream with byteOffset / byteLength', async function (t) {
   t.is(expected.length, 0)
 })
 
+test('basic byte stream with byteOffset / byteLength of a core that has valueEncoding', async function (t) {
+  const core = await create({valueEncoding: "utf8"})
+
+  await core.append([
+    'hello',
+    'world',
+    'verden',
+    'welt'
+  ])
+
+  const opts = { byteOffset: 5, byteLength: 11 }
+  const expected = [
+    'world',
+    'verden'
+  ]
+
+  for await (const data of core.createByteStream(opts)) {
+    t.ok(b4a.isBuffer(data));
+    t.alike(b4a.toString(data), expected.shift())
+  }
+
+  t.is(expected.length, 0)
+})
+
 test('byte stream with lower byteLength than byteOffset', async function (t) {
   const core = await create()
 

--- a/test/streams.js
+++ b/test/streams.js
@@ -122,7 +122,7 @@ test('basic byte stream with byteOffset / byteLength', async function (t) {
 })
 
 test('basic byte stream with byteOffset / byteLength of a core that has valueEncoding', async function (t) {
-  const core = await create({valueEncoding: "utf8"})
+  const core = await create({ valueEncoding: 'utf8' })
 
   await core.append([
     'hello',
@@ -138,7 +138,7 @@ test('basic byte stream with byteOffset / byteLength of a core that has valueEnc
   ]
 
   for await (const data of core.createByteStream(opts)) {
-    t.ok(b4a.isBuffer(data));
+    t.ok(b4a.isBuffer(data))
     t.alike(b4a.toString(data), expected.shift())
   }
 


### PR DESCRIPTION
Added a test as well.

fixes https://github.com/holepunchto/hypercore/issues/457#issue-1989192819