### PR TITLE
Fix HypercoreError in createReadStream after clear

### DIFF
--- a/lib/streams.js
+++ b/lib/streams.js
@@ -32,7 +32,12 @@ class ReadStream extends Readable {
       return
     }
 
-    this.push(await this.core.get(this.start++))
+    const key = this.start++
+    if (await this.core.has(key)) {
+      this.push(await this.core.get(key))
+    } else {
+      this.push(null)
+    }
   }
 }
 


### PR DESCRIPTION
This PR addresses the issue #460  where `createReadStream()` was failing with a `HypercoreError: REQUEST_CANCELLED` after the core had been cleared.

Changes made:
- Check `core.has(key)` before `core.get(key)`
- Added test cases to ensure the read stream operates correctly after a clear operation.

Closes #460 
