### PR TITLE
Add hypertrace instrumentation

### DIFF
--- a/index.js
+++ b/index.js
@@ -969,7 +969,7 @@ module.exports = class Hypercore extends EventEmitter {
   async _download (range) {
     if (this.opened === false) await this.opening
 
-    this.tracer.trace('_download', { range })
+    this.tracer.trace('download', { range })
 
     const activeRequests = (range && range.activeRequests) || this.activeRequests
 

--- a/index.js
+++ b/index.js
@@ -850,7 +850,7 @@ module.exports = class Hypercore extends EventEmitter {
   async get (index, opts) {
     if (this.opened === false) await this.opening
 
-    this.tracer.trace({ index })
+    this.tracer.trace('get', { index })
 
     if (this.closing !== null) throw SESSION_CLOSED()
     if (this._snapshot !== null && index >= this._snapshot.compatLength) throw SNAPSHOT_NOT_AVAILABLE()
@@ -966,7 +966,7 @@ module.exports = class Hypercore extends EventEmitter {
   async _download (range) {
     if (this.opened === false) await this.opening
 
-    this.tracer.trace({ range })
+    this.tracer.trace('_download', { range })
 
     const activeRequests = (range && range.activeRequests) || this.activeRequests
 
@@ -1010,7 +1010,7 @@ module.exports = class Hypercore extends EventEmitter {
     if (writable === false) throw SESSION_NOT_WRITABLE()
 
     blocks = Array.isArray(blocks) ? blocks : [blocks]
-    this.tracer.trace({ blocks })
+    this.tracer.trace('append', { blocks })
 
     const preappend = this.encryption && this._preappend
 

--- a/index.js
+++ b/index.js
@@ -268,6 +268,8 @@ module.exports = class Hypercore extends EventEmitter {
     this.writable = this._isWritable()
     this.autoClose = o.autoClose
 
+    this.tracer.setParent(o.core?.tracer)
+
     if (this.snapshotted && this.core && !this._snapshot) this._updateSnapshot()
   }
 
@@ -378,6 +380,7 @@ module.exports = class Hypercore extends EventEmitter {
       onupdate: this._oncoreupdate.bind(this),
       onconflict: this._oncoreconflict.bind(this)
     })
+    this.tracer.setParent(this.core.tracer)
 
     if (opts.userData) {
       for (const [key, value] of Object.entries(opts.userData)) {

--- a/index.js
+++ b/index.js
@@ -268,7 +268,7 @@ module.exports = class Hypercore extends EventEmitter {
     this.writable = this._isWritable()
     this.autoClose = o.autoClose
 
-    this.tracer.setParent(o.core?.tracer)
+    if (o.core) this.tracer.setParent(o.core.tracer)
 
     if (this.snapshotted && this.core && !this._snapshot) this._updateSnapshot()
   }

--- a/lib/core.js
+++ b/lib/core.js
@@ -10,9 +10,11 @@ const Info = require('./info')
 const { BAD_ARGUMENT, STORAGE_EMPTY, STORAGE_CONFLICT, INVALID_SIGNATURE, INVALID_CHECKSUM } = require('hypercore-errors')
 const m = require('./messages')
 const { manifestHash, createVerifier, createManifest, defaultSignerManifest, isCompat } = require('./manifest')
+const { createTracer } = require('hypertrace')
 
 module.exports = class Core {
   constructor (header, compat, crypto, oplog, bigHeader, tree, blocks, bitfield, verifier, legacy, onupdate, onconflict) {
+    this.tracer = createTracer(this)
     this.onupdate = onupdate
     this.onconflict = onconflict
     this.preupdate = null

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -268,8 +268,8 @@ class BlockTracker {
 }
 
 class Peer {
-  constructor (replicator, protomux, channel, session, coreTracer) {
-    this.tracer = createTracer(this, { parent: coreTracer })
+  constructor (replicator, protomux, channel, session) {
+    this.tracer = createTracer(this, { parent: replicator.core.tracer })
     this.core = replicator.core
     this.replicator = replicator
     this.stream = protomux.stream
@@ -568,7 +568,7 @@ class Peer {
   }
 
   async onrequest (msg) {
-    this.tracer.trace()
+    this.tracer.trace({ msg })
 
     if (!this.protomux.drained || this.receiverQueue.length) {
       this.receiverQueue.push(msg)
@@ -667,7 +667,7 @@ class Peer {
   }
 
   async ondata (data) {
-    this.tracer.trace()
+    this.tracer.trace({ data })
 
     // always allow a fork conflict proof to be sent
     if (data.request === 0 && data.upgrade && data.upgrade.start === 0) {
@@ -728,7 +728,7 @@ class Peer {
   }
 
   onnodata ({ request }) {
-    this.tracer.trace()
+    this.tracer.trace({ request })
 
     const req = request > 0 ? this.replicator._inflight.get(request) : null
 
@@ -1171,8 +1171,6 @@ class Peer {
   }
 
   async _send (req) {
-    this.tracer.trace()
-
     const fork = this.core.tree.fork
 
     this.inflight++
@@ -1201,6 +1199,8 @@ class Peer {
       this.stream.destroy(err)
       return
     }
+
+    this.tracer.trace({ req })
 
     this.wireRequest.send(req)
   }
@@ -2080,7 +2080,7 @@ module.exports = class Replicator {
 
     if (channel === null) return onnochannel()
 
-    const peer = new Peer(replicator, protomux, channel, session, this.core.tracer)
+    const peer = new Peer(replicator, protomux, channel, session)
     const stream = protomux.stream
 
     peer.channel.open({

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -7,6 +7,7 @@ const RemoteBitfield = require('./remote-bitfield')
 const { REQUEST_CANCELLED, REQUEST_TIMEOUT, INVALID_CAPABILITY, SNAPSHOT_NOT_AVAILABLE } = require('hypercore-errors')
 const m = require('./messages')
 const caps = require('./caps')
+const { createTracer } = require('hypertrace')
 
 const DEFAULT_MAX_INFLIGHT = [32, 512]
 const SCALE_LATENCY = 50
@@ -267,7 +268,8 @@ class BlockTracker {
 }
 
 class Peer {
-  constructor (replicator, protomux, channel, session) {
+  constructor (replicator, protomux, channel, session, coreTracer) {
+    this.tracer = createTracer(this, { parent: coreTracer })
     this.core = replicator.core
     this.replicator = replicator
     this.stream = protomux.stream
@@ -429,6 +431,8 @@ class Peer {
   }
 
   onclose (isRemote) {
+    this.tracer.trace()
+
     // we might have signalled to the remote that we are done (ie not downloading) and the remote might agree on that
     // if that happens, the channel might be closed by the remote. if so just renegotiate it.
     // TODO: add a CLOSE_REASON to mux to we can make this cleaner...
@@ -564,6 +568,8 @@ class Peer {
   }
 
   async onrequest (msg) {
+    this.tracer.trace()
+
     if (!this.protomux.drained || this.receiverQueue.length) {
       this.receiverQueue.push(msg)
       return
@@ -661,6 +667,8 @@ class Peer {
   }
 
   async ondata (data) {
+    this.tracer.trace()
+
     // always allow a fork conflict proof to be sent
     if (data.request === 0 && data.upgrade && data.upgrade.start === 0) {
       if (await this.core.checkConflict(data, this)) return
@@ -720,6 +728,8 @@ class Peer {
   }
 
   onnodata ({ request }) {
+    this.tracer.trace()
+
     const req = request > 0 ? this.replicator._inflight.get(request) : null
 
     if (req === null || req.peer !== this) return
@@ -1161,6 +1171,8 @@ class Peer {
   }
 
   async _send (req) {
+    this.tracer.trace()
+
     const fork = this.core.tree.fork
 
     this.inflight++
@@ -1203,6 +1215,7 @@ module.exports = class Replicator {
     onupload = noop,
     oninvalid = noop
   } = {}) {
+    this.tracer = createTracer(this)
     this.key = key
     this.discoveryKey = core.crypto.discoveryKey(key)
     this.core = core
@@ -2067,7 +2080,7 @@ module.exports = class Replicator {
 
     if (channel === null) return onnochannel()
 
-    const peer = new Peer(replicator, protomux, channel, session)
+    const peer = new Peer(replicator, protomux, channel, session, this.core.tracer)
     const stream = protomux.stream
 
     peer.channel.open({

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -431,7 +431,7 @@ class Peer {
   }
 
   onclose (isRemote) {
-    this.tracer.trace()
+    this.tracer.trace('onclose')
 
     // we might have signalled to the remote that we are done (ie not downloading) and the remote might agree on that
     // if that happens, the channel might be closed by the remote. if so just renegotiate it.
@@ -568,7 +568,7 @@ class Peer {
   }
 
   async onrequest (msg) {
-    this.tracer.trace({ msg })
+    this.tracer.trace('onrequest', { msg })
 
     if (!this.protomux.drained || this.receiverQueue.length) {
       this.receiverQueue.push(msg)
@@ -667,7 +667,7 @@ class Peer {
   }
 
   async ondata (data) {
-    this.tracer.trace({ data })
+    this.tracer.trace('ondata', { data })
 
     // always allow a fork conflict proof to be sent
     if (data.request === 0 && data.upgrade && data.upgrade.start === 0) {
@@ -728,7 +728,7 @@ class Peer {
   }
 
   onnodata ({ request }) {
-    this.tracer.trace({ request })
+    this.tracer.trace('onnodata', { request })
 
     const req = request > 0 ? this.replicator._inflight.get(request) : null
 
@@ -1200,7 +1200,7 @@ class Peer {
       return
     }
 
-    this.tracer.trace({ req })
+    this.tracer.trace('_send', { req })
 
     this.wireRequest.send(req)
   }

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -1200,7 +1200,7 @@ class Peer {
       return
     }
 
-    this.tracer.trace('_send', req)
+    this.tracer.trace('send', req)
 
     this.wireRequest.send(req)
   }

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -568,7 +568,7 @@ class Peer {
   }
 
   async onrequest (msg) {
-    this.tracer.trace('onrequest', { msg })
+    this.tracer.trace('onrequest', msg)
 
     if (!this.protomux.drained || this.receiverQueue.length) {
       this.receiverQueue.push(msg)
@@ -667,7 +667,7 @@ class Peer {
   }
 
   async ondata (data) {
-    this.tracer.trace('ondata', { data })
+    this.tracer.trace('ondata', data)
 
     // always allow a fork conflict proof to be sent
     if (data.request === 0 && data.upgrade && data.upgrade.start === 0) {
@@ -1200,7 +1200,7 @@ class Peer {
       return
     }
 
-    this.tracer.trace('_send', { req })
+    this.tracer.trace('_send', req)
 
     this.wireRequest.send(req)
   }

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "hypercore-crypto": "^3.2.1",
     "hypercore-errors": "^1.1.0",
     "hypercore-id-encoding": "^1.2.0",
+    "hypertrace": "file:../hypertrace",
     "is-options": "^1.0.1",
     "protomux": "^3.5.0",
     "quickbit-universal": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "hypercore-crypto": "^3.2.1",
     "hypercore-errors": "^1.1.0",
     "hypercore-id-encoding": "^1.2.0",
-    "hypertrace": "^1.0.0",
+    "hypertrace": "^1.1.0",
     "is-options": "^1.0.1",
     "protomux": "^3.5.0",
     "quickbit-universal": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "hypercore-crypto": "^3.2.1",
     "hypercore-errors": "^1.1.0",
     "hypercore-id-encoding": "^1.2.0",
-    "hypertrace": "file:../hypertrace",
+    "hypertrace": "^1.0.0",
     "is-options": "^1.0.1",
     "protomux": "^3.5.0",
     "quickbit-universal": "^2.2.0",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "hypercore-crypto": "^3.2.1",
     "hypercore-errors": "^1.1.0",
     "hypercore-id-encoding": "^1.2.0",
-    "hypertrace": "^1.1.0",
+    "hypertrace": "^1.2.0",
     "is-options": "^1.0.1",
     "protomux": "^3.5.0",
     "quickbit-universal": "^2.2.0",


### PR DESCRIPTION
# Hypercore speedtest

All these tests have been performed by running `$ npm test` in hypercore on my macbook M1

In each case, it was run 10 times and an average was counted.

## Summary

There was no significant difference between running on an instrumented (but not actively tracing) code base vs a non-instrumented one.

When starting to trace (i.e. `setTraceFunction()` have been called) there was a ~40% increase in overhead.

When starting to trace, but using cache, by `.trace(cacheId)` there was a ~10% increase in overhead.

In real-life cases with long-lived objects the overhead is insignificant.

## 1. Without hypertrace instrumentation added

This is from the `main` hypercore branch without any instrumentation added

```
# time = 10845.309917ms
# time = 10951.91625ms
# time = 10950.779916ms
# time = 11360.088333ms
# time = 9467.811375ms
# time = 9663.833167ms
# time = 10812.367917ms
# time = 11270.643792ms
# time = 9504.236916ms
# time = 9521.476208ms
# ======================
# avg  = 10434.8463791ms
```


## 2. With hypertrace instrumentation added

### 2a. Without using setTraceFunction

Using `createTracer()`, `.trace()`, but not `setTraceFunction()`


```
# time = 10157.106042ms
# time = 11162.466041ms
# time = 10852.541959ms
# time = 10037.762541ms
# time = 11161.77325ms
# time = 11033.951375ms
# time = 10692.505ms
# time = 11217.457667ms
# time = 11003.730792ms
# time = 9489.278625ms
# ======================
# avg  = 10680.8573292ms
```

### 2b. While using setTraceFunction(() => { })), and also using a cacheId

Using `createTracer()`, `.trace(cacheId)`, and `setTraceFunctio()`.

All calls to `.trace()` have a cache id similar to the function name:
``` js
  send () {
    this.tracer.trace('send')
    ...
  }
```

```
# time = 10983.720042ms
# time = 10053.00875ms
# time = 10984.808667ms
# time = 9447.403042ms
# time = 10707.983666ms
# time = 10521.029334ms
# time = 9876.588375ms
# time = 11113.740125ms
# time = 11134.92525ms
# time = 10559.54175ms
# ===================
# avg  = 10538.2749001ms
```

### 2c. While using setTraceFunction(() => { }), but no cacheId

Using `createTracer()`, `.trace()`, and `setTraceFunction()`.

This is added to the very first line of `index.js`:

``` js
const { setTraceFunction } = require('hypertrace')
let tracesCount = 0
setTraceFunction(() => { tracesCount++ })
process.on('exit', () => console.log(`trace function called ${tracesCount} times`))
```

There was an average of 251,540 calls to the trace function when running the tests

```
# time = 14284.143125ms
# time = 14546.467542ms
# time = 14444.38875ms
# time = 14550.258416ms
# time = 14664.504209ms
# time = 13550.680334ms
# time = 14850.7915ms
# time = 14498.501041ms
# time = 13862.527833ms
# time = 14399.782458ms
# ======================
# avg  = 14365,2045208ms
```
