### PR TITLE
Pause on full storage

### DIFF
--- a/lib/block-store.js
+++ b/lib/block-store.js
@@ -1,4 +1,5 @@
 const b4a = require('b4a')
+const { WRITE_FAILED } = require('hypercore-errors')
 
 module.exports = class BlockStore {
   constructor (storage, tree) {
@@ -54,7 +55,7 @@ module.exports = class BlockStore {
   _write (offset, data) {
     return new Promise((resolve, reject) => {
       this.storage.write(offset, data, (err) => {
-        if (err) reject(err)
+        if (err) reject(WRITE_FAILED(err.message))
         else resolve(offset + data.byteLength)
       })
     })

--- a/lib/oplog.js
+++ b/lib/oplog.js
@@ -1,7 +1,7 @@
 const cenc = require('compact-encoding')
 const b4a = require('b4a')
 const { crc32 } = require('crc-universal')
-const { OPLOG_CORRUPT, OPLOG_HEADER_OVERFLOW } = require('hypercore-errors')
+const { OPLOG_CORRUPT, OPLOG_HEADER_OVERFLOW, WRITE_FAILED } = require('hypercore-errors')
 
 module.exports = class Oplog {
   constructor (storage, { pageSize = 4096, headerEncoding = cenc.raw, entryEncoding = cenc.raw, readonly = false } = {}) {
@@ -216,7 +216,7 @@ module.exports = class Oplog {
   _append (buf, count) {
     return new Promise((resolve, reject) => {
       this.storage.write(this._entryOffset + this.byteLength, buf, err => {
-        if (err) return reject(err)
+        if (err) return reject(WRITE_FAILED(err.message))
 
         this.byteLength += buf.byteLength
         this.length += count

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -706,6 +706,14 @@ class Peer {
       }
     } catch (err) {
       safetyCatch(err)
+
+      if (err.code === 'WRITE_FAILED') {
+        // For example, we don't want to keep pulling data when storage is full
+        // TODO: notify the user somehow
+        this.paused = true
+        return
+      }
+
       if (this.core.closed && !isCriticalError(err)) return
 
       if (err.code !== 'INVALID_OPERATION') {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "fast-fifo": "^1.3.0",
     "flat-tree": "^1.9.0",
     "hypercore-crypto": "^3.2.1",
-    "hypercore-errors": "^1.1.0",
+    "hypercore-errors": "holepunchto/hypercore-errors#add-write-failed",
     "hypercore-id-encoding": "^1.2.0",
     "hypertrace": "^1.2.1",
     "is-options": "^1.0.1",


### PR DESCRIPTION
Requires https://github.com/holepunchto/hypercore-errors/pull/2/files (draft till then)

Solves a bug where a peer who runs out of storage eternally requests the same blocks. Instead, it now pauses replication.

Marked as TODO that we should communicate this by emitting an event.

Note: the behaviour changes subtly: before, we would crash if random-access-storage throws a non-safetycaught error on write. This PR changes all errors in `WRITE_FAILED` errors. We could keep the old behaviour by checking safetyCatch before turning the errors into `WRITE_FAILED`.

Note: random-access-storage `write` is called elsewhere in Hyeprcore too. This PR only changes those occurrences which cause the bug, but a follow-up PR should transform the errors there as well.