### PR TITLE
Don't start downloading when core is not active

### DIFF
--- a/index.js
+++ b/index.js
@@ -396,6 +396,7 @@ module.exports = class Hypercore extends EventEmitter {
       eagerUpgrade: true,
       notDownloadingLinger: opts.notDownloadingLinger,
       allowFork: opts.allowFork !== false,
+      initDownloading: this._active,
       onpeerupdate: this._onpeerupdate.bind(this),
       onupload: this._onupload.bind(this),
       oninvalid: this._oninvalid.bind(this)

--- a/index.js
+++ b/index.js
@@ -396,7 +396,6 @@ module.exports = class Hypercore extends EventEmitter {
       eagerUpgrade: true,
       notDownloadingLinger: opts.notDownloadingLinger,
       allowFork: opts.allowFork !== false,
-      initDownloading: this._active,
       onpeerupdate: this._onpeerupdate.bind(this),
       onupload: this._onupload.bind(this),
       oninvalid: this._oninvalid.bind(this)

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -1219,6 +1219,7 @@ module.exports = class Replicator {
     notDownloadingLinger = NOT_DOWNLOADING_SLACK,
     eagerUpgrade = true,
     allowFork = true,
+    initDownloading = true,
     onpeerupdate = noop,
     onupload = noop,
     oninvalid = noop
@@ -1236,7 +1237,7 @@ module.exports = class Replicator {
     this.peers = []
     this.findingPeers = 0 // updateable from the outside
     this.destroyed = false
-    this.downloading = true
+    this.downloading = initDownloading
     this.activeSessions = 0
 
     this._attached = new Set()

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -1219,7 +1219,6 @@ module.exports = class Replicator {
     notDownloadingLinger = NOT_DOWNLOADING_SLACK,
     eagerUpgrade = true,
     allowFork = true,
-    initDownloading = true,
     onpeerupdate = noop,
     onupload = noop,
     oninvalid = noop
@@ -1237,7 +1236,7 @@ module.exports = class Replicator {
     this.peers = []
     this.findingPeers = 0 // updateable from the outside
     this.destroyed = false
-    this.downloading = initDownloading
+    this.downloading = false
     this.activeSessions = 0
 
     this._attached = new Set()

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -1,5 +1,6 @@
 const test = require('brittle')
 const b4a = require('b4a')
+const RAM = require('random-access-memory')
 const NoiseSecretStream = require('@hyperswarm/secret-stream')
 const { create, replicate, unreplicate, eventFlush } = require('./helpers')
 const { makeStreamPair } = require('./helpers/networking.js')
@@ -22,6 +23,27 @@ test('basic replication', async function (t) {
   await r.done()
 
   t.is(d, 5)
+})
+
+test('basic downloading is set immediately after ready', function (t) {
+  t.plan(2)
+
+  const a = new Hypercore(RAM)
+
+  a.on('ready', function () {
+    t.ok(a.replicator.downloading)
+  })
+
+  const b = new Hypercore(RAM, { active: false })
+
+  b.on('ready', function () {
+    t.absent(b.replicator.downloading)
+  })
+
+  t.teardown(async () => {
+    await a.close()
+    await b.close()
+  })
 })
 
 test('basic replication from fork', async function (t) {


### PR DESCRIPTION
Current behaviour doesn't interact well with corestore, because whenever a peer connects on a discovery key with you, this line is called:
https://github.com/holepunchto/corestore/blob/3ab2595c8313179bc98567dbe28389245ddca6e8/index.js#L345

Even though `active: false` is passed in when creating the core, when `this.downloading` is true (which it always is initially) you still end up requesting a download from all the other peers you're connected with on that core, and they end up doing the same, so it propagates.

Note: I'm not sure why `this.downloading` had default true. This is a big behaviour change, so might break something. Fwiw, tests also pass when it's defaulted to false.
