### PR TITLE
Make waitForRequestBlock run every event loop

### DIFF
--- a/test/replicate.js
+++ b/test/replicate.js
@@ -1486,12 +1486,12 @@ test('replication updates on core copy', async function (t) {
   await t.execution(promise)
 })
 
-async function waitForRequestBlock (core, opts) {
+async function waitForRequestBlock (core) {
   while (true) {
     const reqBlock = core.replicator._inflight._requests.find(req => req && req.block)
     if (reqBlock) break
 
-    await new Promise(resolve => setTimeout(resolve, 1))
+    await new Promise(resolve => setImmediate(resolve))
   }
 }
 


### PR DESCRIPTION
The `try cancel block from a different session` test was occasionally hanging (maybe 1/1000 runs).

I couldn't trace exactly why (even just adding log statements threw off the timing sufficiently to make it always pass) but a possible cause is that the loop in `waitForRequestBlock` skipped over the request, which in the previous code is possible if it's extremely short-lived (~1ms). By using `setImmediate` that should no longer be possible

Note: also got rid of the unused opts argument