### PR TITLE
Get undefined block is not allowed

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -428,3 +428,16 @@ test('append above the max suggested block size', async function (t) {
     t.pass('should throw')
   }
 })
+
+test('get undefined block is not allowed', async function (t) {
+  t.plan(1)
+
+  const core = new Hypercore(RAM)
+
+  try {
+    await core.get(undefined)
+    t.fail()
+  } catch (err) {
+    t.pass(err.code, 'ERR_ASSERTION')
+  }
+})

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -2,7 +2,7 @@ const test = require('brittle')
 const b4a = require('b4a')
 const RAM = require('random-access-memory')
 const NoiseSecretStream = require('@hyperswarm/secret-stream')
-const { create, replicate, unreplicate, eventFlush, createStored } = require('./helpers')
+const { create, replicate, unreplicate, eventFlush } = require('./helpers')
 const { makeStreamPair } = require('./helpers/networking.js')
 const Hypercore = require('../')
 
@@ -1484,57 +1484,6 @@ test('replication updates on core copy', async function (t) {
   b.core.copyFrom(a.core, b4a.from(a.core.tree.signature))
 
   await t.execution(promise)
-})
-
-test('get undefined block should not fail', async function (t) {
-  const a = await create()
-  const b = await create(a.key)
-
-  await a.append('Hello') // Strictly one value is required for this
-
-  replicate(a, b, t)
-
-  t.alike(await b.get(0), b4a.from('Hello'))
-
-  try {
-    await b.get(undefined)
-  } catch (err) {
-    console.error(err) // Error: Could not satisfy length (EPARTIALREAD when using RAF)
-    t.fail()
-  }
-})
-
-test.skip('get undefined block should not allow corruption on the writer', async function (t) {
-  const createWriter = createStored()
-
-  const a = createWriter()
-  await a.append(['Hello', 'World']) // Strictly two values is required for this
-
-  const b = await create(a.key)
-
-  replicate(a, b, t)
-
-  await b.update({ wait: true })
-
-  t.alike(await b.get(0), b4a.from('Hello'))
-
-  await b.get(undefined) // This triggers 100% CPU usage
-
-  // TODO: Check that writer can still write two values without corrupting itself? (unfinished due the glitch above)
-  /* await a.close()
-  await b.close()
-
-  const core = createWriter()
-  await core.append(['Hello', 'World']) // Strictly two values is required for this
-
-  const clone = await create(core.key)
-
-  replicate(core, clone, t)
-
-  await clone.update({ wait: true })
-
-  t.alike(await b.get(0), b4a.from('Hello'))
-  await b.get(undefined) // TODO: Over here triggers "Error: Could not load node: X" */
 })
 
 async function waitForRequestBlock (core) {


### PR DESCRIPTION
Tests produces different errors but they look related thus same PR

The second test is skipped due high CPU usage, by unskipping it locally you can reproduce

Later, to reproduce the final "Error: Could not load node: 4" the test can be adjusted after the CPU fix or it can be reproduced at the moment by running this script twice:

```js
const Hypercore = require('hypercore')

main()

async function main () {
  const core = new Hypercore('./data-w')
  await core.append(['Hello', 'World']) // Two values is required for this

  const clone = new Hypercore('./data-r', core.key)

  const s1 = core.replicate(true)
  const s2 = clone.replicate(false)

  s1.pipe(s2).pipe(s1)

  await clone.update({ wait: true })

  console.log('0', await clone.get(0))
  console.log('undef', await clone.get(undefined))

  await clone.close()
}
```

When running it for the first time it will use 100% CPU, do CTRL-C, and re-run it again then error should happen

It seems that the writer is only left sensible after the first run because if you remove the .append before the second run then everything appears to be fine but it is not lol, just corruption or whatever waiting to happen