### PR TITLE
Bugfix: treeHash for not-locally-available block

### DIFF
--- a/index.js
+++ b/index.js
@@ -1047,11 +1047,15 @@ module.exports = class Hypercore extends EventEmitter {
     return this.core.append(buffers, { keyPair, signature, preappend })
   }
 
-  async treeHash (length) {
+  async treeHash (length, opts = {}) {
+    if (!this.opened) await this.ready()
+
     if (length === undefined) {
-      await this.ready()
       length = this.core.tree.length
     }
+
+    // Ensure the block corresponding with the length is locally available
+    if (length > 0) await this.get(length - 1, opts)
 
     const roots = await this.core.tree.getRoots(length)
     return this.crypto.tree(roots)


### PR DESCRIPTION
Current behaviour is a low-level error, even when the required block is available from the swarm and `core.length` is higher:
``
/home/hans/holepunch/hypercore/node_modules/random-access-memory/index.js:86
      return req.callback(new Error('Could not satisfy length'), null)
                          ^

Error: Could not satisfy length
    at RAM._read (/home/hans/holepunch/hypercore/node_modules/random-access-memory/index.js:86:27)
    at Request._run (/home/hans/holepunch/hypercore/node_modules/random-access-storage/index.js:258:42)
    at RAM.run (/home/hans/holepunch/hypercore/node_modules/random-access-storage/index.js:153:14)
    at RAM.read (/home/hans/holepunch/hypercore/node_modules/random-access-storage/index.js:60:10)
    at /home/hans/holepunch/hypercore/lib/merkle-tree.js:1111:13
    at new Promise (<anonymous>)
    at getStoredNode (/home/hans/holepunch/hypercore/lib/merkle-tree.js:1110:10)
    at MerkleTree.get (/home/hans/holepunch/hypercore/lib/merkle-tree.js:470:12)
    at MerkleTree.getRoots (/home/hans/holepunch/hypercore/lib/merkle-tree.js:422:23)
    at Hypercore.treeHash (/home/hans/holepunch/hypercore/index.js:1060:40)
```

Note: also always running the opened-check now, because calling `treeHash(...)` with a specified length without awaiting `ready` causes a crash (`this.core.tree` doesn't exist yet)