### PR TITLE
Trace _requestRangBlock and _send start

### DIFF
--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -1034,6 +1034,7 @@ class Peer {
   }
 
   _requestRangeBlock (index, length) {
+    this.tracer.trace('_requestRangeBlock')
     if (this.core.bitfield.get(index) === true || !this._hasTreeParent(index)) return false
 
     const b = this.replicator._blocks.add(index, PRIORITY.NORMAL)
@@ -1179,6 +1180,7 @@ class Peer {
   }
 
   async _send (req) {
+    this.tracer.trace('_send-start')
     const fork = this.core.tree.fork
 
     this.inflight++


### PR DESCRIPTION
Note: _send already has some tracing at the end: https://github.com/holepunchto/hypercore/blob/64116ee4aa66379168b706acb976dd54e1f93f4f/lib/replicator.js#L1211
But there are some early-return flows, so I think it makes sense to trace the beginning too