### PR TITLE
Pass inflightRange on to new session

### DIFF
--- a/index.js
+++ b/index.js
@@ -225,6 +225,10 @@ module.exports = class Hypercore extends EventEmitter {
       throw SESSION_CLOSED('Cannot make sessions on a closing core')
     }
 
+    if (!opts.inflightRange && this.inflightRange) {
+      opts.inflightRange = this.inflightRange
+    }
+
     const sparse = opts.sparse === false ? false : this.sparse
     const wait = opts.wait === false ? false : this.wait
     const writable = opts.writable === false ? false : !this._readonly

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -1506,6 +1506,24 @@ test('can define default max-inflight blocks for replicator peers', async functi
   )
 })
 
+test('default inflightRange passed to new session', async function (t) {
+  const a = new Hypercore(RAM, { inflightRange: [123, 123] })
+  const session = a.session()
+
+  t.alike(
+    session.inflightRange,
+    [123, 123],
+    'inflightRange passed on to session'
+  )
+
+  const overwrittenSession = a.session({ inflightRange: [1, 2] })
+  t.alike(
+    overwrittenSession.inflightRange,
+    [1, 2],
+    'can pass explicit inflightRange to session'
+  )
+})
+
 async function waitForRequestBlock (core) {
   while (true) {
     const reqBlock = core.replicator._inflight._requests.find(req => req && req.block)


### PR DESCRIPTION
Note: I could do the same for the 'clone' method, which currently doesn't pass on `inflightRange`. Unsure if that makes sense though (I've never used `clone`)