### PR TITLE
chore: Remove unused `length` arg in `bitfield.getBitfield()`

### DIFF
--- a/lib/bitfield.js
+++ b/lib/bitfield.js
@@ -237,7 +237,7 @@ module.exports = class Bitfield {
     return buffer
   }
 
-  getBitfield (index, length) {
+  getBitfield (index) {
     const j = index & (BITS_PER_PAGE - 1)
     const i = (index - j) / BITS_PER_PAGE
 


### PR DESCRIPTION
Looks like it was never used. Likely accidentally included.