### PR TITLE
Copy node-cache entries to reduce mem usage

### DIFF
--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -546,6 +546,7 @@ module.exports = class MerkleTree {
     if (c) return c
 
     let node = this.unflushed.get(index)
+
     if (this.flushing !== null && node === undefined) {
       node = this.flushing.get(index)
     }

--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -1206,18 +1206,15 @@ function blankNode (index) {
 // Storage methods
 
 function getStoredNode (storage, index, cache, error) {
-  const nodeSize = 40
-
   return new Promise((resolve, reject) => {
-    storage.read(nodeSize * index, nodeSize, (err, data) => {
+    storage.read(40 * index, 40, (err, data) => {
       if (err) {
         if (error) return reject(err)
         else resolve(null)
         return
       }
 
-      const uintNrBytes = 8
-      const hash = data.subarray(uintNrBytes)
+      const hash = data.subarray(8)
       const size = c.decode(c.uint64, data)
 
       if (size === 0 && b4a.compare(hash, BLANK_HASH) === 0) {

--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -1229,18 +1229,8 @@ function getStoredNode (storage, index, cache, error) {
       const node = { index, size, hash }
 
       if (cache !== null) {
-        const slab = b4a.alloc(nodeSize)
-        b4a.copy(data, slab)
-
-        const sizeCopy = c.decode(
-          c.uint64,
-          slab.subarray(0, uintNrBytes)
-        )
-
-        const hashCopy = slab.subarray(uintNrBytes, slab.byteLength)
-
-        // Note: index is assumed not to be a slab-allocated buffer, so not copied
-        node.size = sizeCopy
+        const hashCopy = b4a.alloc(hash.byteLength)
+        b4a.copy(hash, hashCopy)
         node.hash = hashCopy
 
         cache.set(index, node)

--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -1226,6 +1226,9 @@ function getStoredNode (storage, index, cache, error) {
       const node = { index, size, hash }
 
       if (cache !== null) {
+        // The hash is allocated from a slab.
+        // To avoid blocking gc of that slab for the duration it is stored
+        // in the cache, it is copied to a new buffer.
         const hashCopy = b4a.alloc(hash.byteLength)
         b4a.copy(hash, hashCopy)
         node.hash = hashCopy

--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -546,7 +546,6 @@ module.exports = class MerkleTree {
     if (c) return c
 
     let node = this.unflushed.get(index)
-
     if (this.flushing !== null && node === undefined) {
       node = this.flushing.get(index)
     }
@@ -1206,15 +1205,18 @@ function blankNode (index) {
 // Storage methods
 
 function getStoredNode (storage, index, cache, error) {
+  const nodeSize = 40
+
   return new Promise((resolve, reject) => {
-    storage.read(40 * index, 40, (err, data) => {
+    storage.read(nodeSize * index, nodeSize, (err, data) => {
       if (err) {
         if (error) return reject(err)
         else resolve(null)
         return
       }
 
-      const hash = data.subarray(8)
+      const uintNrBytes = 8
+      const hash = data.subarray(uintNrBytes)
       const size = c.decode(c.uint64, data)
 
       if (size === 0 && b4a.compare(hash, BLANK_HASH) === 0) {
@@ -1224,7 +1226,25 @@ function getStoredNode (storage, index, cache, error) {
       }
 
       const node = { index, size, hash }
-      if (cache !== null) cache.set(index, node)
+
+      if (cache !== null) {
+        const slab = b4a.alloc(nodeSize)
+        b4a.copy(data, slab)
+
+        const sizeCopy = c.decode(
+          c.uint64,
+          slab.subarray(0, uintNrBytes)
+        )
+
+        const hashCopy = slab.subarray(uintNrBytes, slab.byteLength)
+
+        // Note: index is assumed not to be a slab-allocated buffer, so not copied
+        node.size = sizeCopy
+        node.hash = hashCopy
+
+        cache.set(index, node)
+      }
+
       resolve(node)
     })
   })

--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -1226,11 +1226,9 @@ function getStoredNode (storage, index, cache, error) {
       const node = { index, size, hash }
 
       if (cache !== null) {
-        // The hash is allocated from a slab.
-        // To avoid blocking gc of that slab for the duration it is stored
-        // in the cache, it is copied to a new buffer.
+        // Copy hash to a new buffer to avoid blocking gc of its original slab
         const hashCopy = b4a.alloc(hash.byteLength)
-        b4a.copy(hash, hashCopy)
+        hashCopy.set(hash)
         node.hash = hashCopy
 
         cache.set(index, node)

--- a/test/merkle-tree.js
+++ b/test/merkle-tree.js
@@ -620,6 +620,8 @@ test('buffer of cached nodes is copied to small slab', async function (t) {
 
   const node = await tree.get(0)
   t.is(node.hash.buffer.byteLength, 40, 'created a new memory slab of the correct (small) size')
+
+  await tree.close()
 })
 
 async function audit (tree) {

--- a/test/merkle-tree.js
+++ b/test/merkle-tree.js
@@ -1,6 +1,9 @@
+const path = require('path')
 const test = require('brittle')
 const RAM = require('random-access-memory')
 const b4a = require('b4a')
+const RandomAccessFile = require('random-access-file')
+const createTempDir = require('test-tmp')
 const Tree = require('../lib/merkle-tree')
 
 test('nodes', async function (t) {
@@ -597,6 +600,26 @@ test('checkout nodes in a batch', async t => {
   const nodes = b.nodes.sort((a, b) => a.index - b.index).map(n => n.index)
 
   t.alike(nodes, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18, 19, 20, 21, 22, 24, 25, 26, 28])
+})
+
+test('buffer of cached nodes is copied to small slab', async function (t) {
+  // RAM does not use slab-allocated memory,
+  // so we need to us random-access-file to reproduce this issue
+  const dir = await createTempDir(t)
+  const storage = new RandomAccessFile(path.join(dir, 'tree'))
+
+  const tree = await Tree.open(storage)
+
+  const b = tree.batch()
+  b.append(b4a.from('tree-entry'))
+  b.commit()
+
+  // Note: if the batch is committed but not yet flushed,
+  // it still uses the original slab-allocated memory
+  await tree.flush()
+
+  const node = await tree.get(0)
+  t.is(node.hash.buffer.byteLength, 40, 'created a new memory slab of the correct (small) size')
 })
 
 async function audit (tree) {

--- a/test/merkle-tree.js
+++ b/test/merkle-tree.js
@@ -619,7 +619,7 @@ test('buffer of cached nodes is copied to small slab', async function (t) {
   await tree.flush()
 
   const node = await tree.get(0)
-  t.is(node.hash.buffer.byteLength, 40, 'created a new memory slab of the correct (small) size')
+  t.is(node.hash.buffer.byteLength, 32, 'created a new memory slab of the correct (small) size')
 
   await tree.close()
 })


### PR DESCRIPTION
Context: random-access-file uses slab-allocated memory by default when reading from disk. Since we store the nodes in a cache, the entire slab is kept from being garbage-collected. This PR copies the cache entry to a new, smaller slab.