### PR TITLE
never send an invalid block request

### DIFF
--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -1351,12 +1351,14 @@ async function generateProof (tree, block, hash, seek, upgrade) {
   const [pNode, pSeek, pUpgrade, pAdditional] = await settleProof(p)
 
   if (block) {
+    if (pNode === null) throw INVALID_OPERATION('Invalid block request')
     result.block = {
       index: block.index,
       value: null, // populated upstream, alloc it here for simplicity
       nodes: pNode
     }
   } else if (hash) {
+    if (pNode === null) throw INVALID_OPERATION('Invalid hash request')
     result.hash = {
       index: hash.index,
       nodes: pNode

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -1021,8 +1021,13 @@ class Peer {
     this.protomux.uncork()
   }
 
-  _makeRequest (needsUpgrade, priority) {
+  _makeRequest (needsUpgrade, priority, minLength) {
     if (needsUpgrade === true && this.replicator._shouldUpgrade(this) === false) {
+      return null
+    }
+
+    // ensure that the remote has signalled they have the length we request
+    if (this.remoteLength < minLength) {
       return null
     }
 
@@ -1048,12 +1053,12 @@ class Peer {
   }
 
   _requestManifest () {
-    const req = this._makeRequest(false, 0)
+    const req = this._makeRequest(false, 0, 0)
     this._send(req)
   }
 
   _requestUpgrade (u) {
-    const req = this._makeRequest(true, 0)
+    const req = this._makeRequest(true, 0, 0)
     if (req === null) return false
 
     this._send(req)
@@ -1070,7 +1075,7 @@ class Peer {
     if (fork !== this.remoteFork) return false
 
     if (s.seeker.start >= length) {
-      const req = this._makeRequest(true, 0)
+      const req = this._makeRequest(true, 0, 0)
 
       // We need an upgrade for the seek, if non can be provided, skip
       if (req === null) return false
@@ -1102,7 +1107,7 @@ class Peer {
       const h = this.replicator._hashes.add(index, PRIORITY.NORMAL)
       if (h.inflight.length > 0) continue
 
-      const req = this._makeRequest(false, h.priority)
+      const req = this._makeRequest(false, h.priority, index + 1)
       const nodes = flatTree.depth(s.seeker.start + s.seeker.end - 1)
 
       req.hash = { index: 2 * index, nodes }
@@ -1175,7 +1180,7 @@ class Peer {
       return false
     }
 
-    const req = this._makeRequest(b.index >= length, b.priority)
+    const req = this._makeRequest(b.index >= length, b.priority, b.index + 1)
     if (req === null) return false
 
     this._sendBlockRequest(req, b)
@@ -1192,7 +1197,7 @@ class Peer {
       return false
     }
 
-    const req = this._makeRequest(index >= length, b.priority)
+    const req = this._makeRequest(index >= length, b.priority, index + 1)
 
     // If the request cannot be satisfied, dealloc the block request if no one is subscribed to it
     if (req === null) {
@@ -1269,7 +1274,7 @@ class Peer {
   }
 
   _requestForkProof (f) {
-    const req = this._makeRequest(false, 0)
+    const req = this._makeRequest(false, 0, 0)
 
     req.upgrade = { start: 0, length: this.remoteLength }
     req.manifest = !this.core.header.manifest
@@ -1293,7 +1298,7 @@ class Peer {
 
       if (this._remoteHasBlock(index) === false) continue
 
-      const req = this._makeRequest(false, 0)
+      const req = this._makeRequest(false, 0, 0)
 
       req.hash = { index: 2 * index, nodes: f.batch.want.nodes }
 


### PR DESCRIPTION
Really hard to encapsulate in a test case unfortunately but there is a bug where if we can a range update before a sync update, then we might request an OOB block (which crashes it atm)

This fixes the crash, but also makes sure to not send invalid requests in the first place