### PR TITLE
Support globalCache option

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,6 @@ module.exports = class Hypercore extends EventEmitter {
     this.replicator = null
     this.encryption = null
     this.extensions = new Map()
-    this.globalCache = opts.globalCache
     this.cache = createCache(opts.cache)
 
     this.valueEncoding = null
@@ -239,8 +238,7 @@ module.exports = class Hypercore extends EventEmitter {
       timeout,
       writable,
       _opening: this.opening,
-      _sessions: this.sessions,
-      globalCache: this.globalCache
+      _sessions: this.sessions
     })
 
     s._passCapabilities(this)
@@ -390,6 +388,7 @@ module.exports = class Hypercore extends EventEmitter {
       crypto: this.crypto,
       legacy: opts.legacy,
       manifest: opts.manifest,
+      globalCache: opts.globalCache || null,
       onupdate: this._oncoreupdate.bind(this),
       onconflict: this._oncoreconflict.bind(this)
     })
@@ -591,6 +590,10 @@ module.exports = class Hypercore extends EventEmitter {
 
   get padding () {
     return this.encryption === null ? 0 : this.encryption.padding
+  }
+
+  get globalCache () {
+    return this.core?.globalCache || null
   }
 
   ready () {

--- a/index.js
+++ b/index.js
@@ -388,7 +388,7 @@ module.exports = class Hypercore extends EventEmitter {
       crypto: this.crypto,
       legacy: opts.legacy,
       manifest: opts.manifest,
-      globalCache: opts.globalCache || null,
+      globalCache: opts.globalCache || null, // This is a temp option, not to be relied on unless you know what you are doing (no semver guarantees)
       onupdate: this._oncoreupdate.bind(this),
       onconflict: this._oncoreconflict.bind(this)
     })

--- a/index.js
+++ b/index.js
@@ -593,7 +593,7 @@ module.exports = class Hypercore extends EventEmitter {
   }
 
   get globalCache () {
-    return this.core?.globalCache || null
+    return this.core && this.core.globalCache
   }
 
   ready () {

--- a/index.js
+++ b/index.js
@@ -62,6 +62,7 @@ module.exports = class Hypercore extends EventEmitter {
     this.replicator = null
     this.encryption = null
     this.extensions = new Map()
+    this.globalCache = opts.globalCache
     this.cache = createCache(opts.cache)
 
     this.valueEncoding = null

--- a/index.js
+++ b/index.js
@@ -239,7 +239,8 @@ module.exports = class Hypercore extends EventEmitter {
       timeout,
       writable,
       _opening: this.opening,
-      _sessions: this.sessions
+      _sessions: this.sessions,
+      globalCache: this.globalCache
     })
 
     s._passCapabilities(this)

--- a/lib/core.js
+++ b/lib/core.js
@@ -15,7 +15,7 @@ const audit = require('./audit')
 const { createTracer } = require('hypertrace')
 
 module.exports = class Core {
-  constructor (header, compat, crypto, oplog, bigHeader, tree, blocks, bitfield, verifier, sessions, legacy, onupdate, onconflict, globalCache) {
+  constructor (header, compat, crypto, oplog, bigHeader, tree, blocks, bitfield, verifier, sessions, legacy, globalCache, onupdate, onconflict) {
     this.tracer = createTracer(this)
     this.onupdate = onupdate
     this.onconflict = onconflict
@@ -195,7 +195,7 @@ module.exports = class Core {
       }
     }
 
-    return new this(header, compat, crypto, oplog, bigHeader, tree, blocks, bitfield, verifier, opts.sessions || [], legacy, opts.onupdate || noop, opts.onconflict || noop, opts.globalCache)
+    return new this(header, compat, crypto, oplog, bigHeader, tree, blocks, bitfield, verifier, opts.sessions || [], legacy, opts.globalCache || null, opts.onupdate || noop, opts.onconflict || noop)
   }
 
   async audit () {

--- a/lib/core.js
+++ b/lib/core.js
@@ -15,7 +15,7 @@ const audit = require('./audit')
 const { createTracer } = require('hypertrace')
 
 module.exports = class Core {
-  constructor (header, compat, crypto, oplog, bigHeader, tree, blocks, bitfield, verifier, sessions, legacy, onupdate, onconflict) {
+  constructor (header, compat, crypto, oplog, bigHeader, tree, blocks, bitfield, verifier, sessions, legacy, onupdate, onconflict, globalCache) {
     this.tracer = createTracer(this)
     this.onupdate = onupdate
     this.onconflict = onconflict
@@ -35,6 +35,7 @@ module.exports = class Core {
     this.skipBitfield = null
     this.active = sessions.length
     this.sessions = sessions
+    this.globalCache = globalCache
 
     this._manifestFlushed = !!header.manifest
     this._maxOplogSize = 65536
@@ -194,7 +195,7 @@ module.exports = class Core {
       }
     }
 
-    return new this(header, compat, crypto, oplog, bigHeader, tree, blocks, bitfield, verifier, opts.sessions || [], legacy, opts.onupdate || noop, opts.onconflict || noop)
+    return new this(header, compat, crypto, oplog, bigHeader, tree, blocks, bitfield, verifier, opts.sessions || [], legacy, opts.onupdate || noop, opts.onconflict || noop, opts.globalCache)
   }
 
   async audit () {

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   "devDependencies": {
     "brittle": "^3.0.0",
     "hyperswarm": "^4.3.6",
+    "rache": "^1.0.0",
     "random-access-memory": "^6.1.0",
     "random-access-memory-overlay": "^3.0.0",
     "range-parser": "^1.2.1",

--- a/test/cache.js
+++ b/test/cache.js
@@ -1,5 +1,6 @@
 const test = require('brittle')
 const Xache = require('xache')
+const Rache = require('rache')
 const b4a = require('b4a')
 const { create, replicate } = require('./helpers')
 
@@ -103,4 +104,18 @@ test('cache is set through preload', async function (t) {
   const a = await create({ async preload () { return { cache: true } } })
 
   t.ok(a.cache)
+})
+
+test('null default for globalCache', async function (t) {
+  const a = await create()
+  t.is(a.globalCache, null)
+})
+
+test('globalCache set if passed in, and shared among sessions', async function (t) {
+  const globalCache = new Rache()
+  const a = await create({ globalCache })
+  t.is(a.globalCache, globalCache, 'cache is stored in hypercore')
+
+  const session = a.session()
+  t.is(session.globalCache, globalCache, 'passed on to sessions')
 })


### PR DESCRIPTION
These are the minimal changes to support a `globalCache` option.

Ideally, Hypercore itself would also use the `globalCache` if `cache` is set to `true`, but the exact lifecycle needs some more thought, so I left that out for now. (The main complexity is that we store the `globalCache` in `Hypercore.core`, which is created only after the hypercore caches have already been defined, in `_openCapabilities`)