### PR TITLE
Bugfix: support very big batches

### DIFF
--- a/lib/batch.js
+++ b/lib/batch.js
@@ -301,7 +301,7 @@ module.exports = class HypercoreBatch extends EventEmitter {
       }
     }
 
-    this._appends.push(...buffers)
+    for (const b of buffers) this._appends.push(b)
 
     const info = { length: this.length, byteLength: this.byteLength }
     this.emit('append')

--- a/test/batch.js
+++ b/test/batch.js
@@ -683,3 +683,18 @@ test('copy from with encrypted batch', async function (t) {
 
   t.alike(tree.hash(), manifest.prologue.hash)
 })
+
+test('batch append with huge batch', async function (t) {
+  // Context: array.append(...otherArray) stops working after a certain amount of entries
+  // due to a limit on the amount of function args
+  // This caused a bug on large batches
+  const core = await create()
+  const bigBatch = (new Array(200_000)).fill('o')
+
+  const b = core.batch()
+  await b.append(bigBatch)
+
+  // Actually flushing such a big batch takes multiple minutes
+  // so we only ensure that nothing crashed while appending
+  t.pass('Can append a big batch')
+})


### PR DESCRIPTION
Previous behaviour was to throw a `RangeError: Maximum call stack size exceeded` (see explanation with the test)