### PR TITLE
Unslab handshake capability

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -2,6 +2,7 @@ const c = require('compact-encoding')
 const b4a = require('b4a')
 const { DEFAULT_NAMESPACE } = require('./caps')
 const { INVALID_OPLOG_VERSION } = require('hypercore-errors')
+const unslab = require('unslab')
 
 const EMPTY = b4a.alloc(0)
 
@@ -244,7 +245,7 @@ wire.handshake = {
     const flags = c.uint.decode(state)
     return {
       seeks: (flags & 1) !== 0,
-      capability: c.fixed32.decode(state)
+      capability: unslab(c.fixed32.decode(state))
     }
   }
 }

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -1537,6 +1537,29 @@ test('restore after cancelled block request', async function (t) {
   t.is(b.length, a.length)
 })
 
+test('handshake is unslabbed', async function (t) {
+  const a = await create()
+
+  await a.append(['a'])
+
+  const b = await create(a.key)
+
+  replicate(a, b, t)
+  const r = b.download({ start: 0, end: a.length })
+  await r.done()
+
+  t.is(
+    a.replicator.peers[0].channel.handshake.capability.buffer.byteLength,
+    32,
+    'unslabbed handshake capability buffer'
+  )
+  t.is(
+    b.replicator.peers[0].channel.handshake.capability.buffer.byteLength,
+    32,
+    'unslabbed handshake capability buffer'
+  )
+})
+
 async function waitForRequestBlock (core) {
   while (true) {
     const reqBlock = core.replicator._inflight._requests.find(req => req && req.block)


### PR DESCRIPTION
The handshake is stored in the protomux channel, which is long lived. Without unslabbing, it retains ~8kb or ~65kb (if it comes from udx).

I don't think the handshake is ever ephemeral, so I opted for the simple solution of unslabbing when decoding the message.