### PR TITLE
Unslab downloaded blocks

### DIFF
--- a/index.js
+++ b/index.js
@@ -915,7 +915,7 @@ module.exports = class Hypercore extends EventEmitter {
     const resolved = await req
 
     // Unslab only when it takes up less then half the slab
-    const block = resolved !== null && 2 * resolved.length < resolved.buffer.byteLength
+    const block = resolved !== null && 2 * resolved.byteLength < resolved.buffer.byteLength
       ? unslab(resolved)
       : resolved
 

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -22,7 +22,6 @@
   The Peer uses this information to decide which blocks to request form the peer in response to _requestRange requests and the like.
 */
 
-const unslab = require('unslab')
 const b4a = require('b4a')
 const safetyCatch = require('safety-catch')
 const RandomIterator = require('random-array-iterator')
@@ -1780,8 +1779,6 @@ module.exports = class Replicator {
   }
 
   _resolveBlockRequest (tracker, index, value, req) {
-    if (value !== null) value = unslab(value)
-
     const b = tracker.remove(index)
     if (b === null) return false
 

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -22,6 +22,7 @@
   The Peer uses this information to decide which blocks to request form the peer in response to _requestRange requests and the like.
 */
 
+const unslab = require('unslab')
 const b4a = require('b4a')
 const safetyCatch = require('safety-catch')
 const RandomIterator = require('random-array-iterator')
@@ -1779,6 +1780,8 @@ module.exports = class Replicator {
   }
 
   _resolveBlockRequest (tracker, index, value, req) {
+    if (value !== null) value = unslab(value)
+
     const b = tracker.remove(index)
     if (b === null) return false
 

--- a/test/cache.js
+++ b/test/cache.js
@@ -76,15 +76,15 @@ test('cache on replicate', async function (t) {
   replicate(a, b, t)
 
   // These will issue a replicator request
-  const p = b.get(0)
-  const q = b.get(0)
+  const p = await b.get(0)
+  const q = await b.get(0)
 
-  t.is(await p, await q, 'blocks are identical')
+  t.is(p, q, 'blocks are identical')
 
   // This should use the cache
-  const r = b.get(0)
+  const r = await b.get(0)
 
-  t.is(await p, await r, 'blocks are identical')
+  t.is(p, r, 'blocks are identical')
 })
 
 test('session cache with different encodings', async function (t) {

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -955,7 +955,7 @@ test('download available blocks on non-sparse update', async function (t) {
   t.is(b.contiguousLength, b.length)
 })
 
-test('downloaded blocks are unslabbed', async function (t) {
+test('downloaded blocks are unslabbed if small', async function (t) {
   const a = await create()
 
   await a.append(Buffer.alloc(1))

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -970,6 +970,30 @@ test('downloaded blocks are unslabbed if small', async function (t) {
   t.is(block.buffer.byteLength, 1, 'unslabbed block')
 })
 
+test('downloaded blocks are not unslabbed if bigger than half of slab size', async function (t) {
+  const a = await create()
+
+  await a.append(Buffer.alloc(5000))
+  t.is(
+    Buffer.poolSize < 5000 * 2,
+    true,
+    'Sanity check (adapt test if fails)'
+  )
+
+  const b = await create(a.key)
+
+  replicate(a, b, t)
+
+  t.is(b.contiguousLength, 0, 'sanity check: we want to receive the downloaded buffer (not from fs)')
+  const block = await b.get(0)
+
+  t.is(
+    block.buffer.byteLength !== block.byteLength,
+    true,
+    'No unslab if big block' // slab includes the protomux frame
+  )
+})
+
 test('sparse replication without gossiping', async function (t) {
   t.plan(4)
 

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -955,6 +955,21 @@ test('download available blocks on non-sparse update', async function (t) {
   t.is(b.contiguousLength, b.length)
 })
 
+test('downloaded blocks are unslabbed', async function (t) {
+  const a = await create()
+
+  await a.append(Buffer.alloc(1))
+
+  const b = await create(a.key)
+
+  replicate(a, b, t)
+
+  t.is(b.contiguousLength, 0, 'sanity check: we want to receive the downloaded buffer (not from fs)')
+  const block = await b.get(0)
+
+  t.is(block.buffer.byteLength, 1, 'unslabbed block')
+})
+
 test('sparse replication without gossiping', async function (t) {
   t.plan(4)
 


### PR DESCRIPTION
Currently, downloaded blocks retain their slab (8kb, or 65kb if udx is used).

<strike>If the hypercore cache is activated, that takes up a lot of memory. But I think it makes sense to always unslab the blocks, regardless of whether they are cached (this makes the fix much easier). </strike>
We ended up unslabbing only in cacheOnResolve. Note that this slightly changes the caching behaviour in case of a parallel first get (see the modified test)