### PR TITLE
Unslab merkle-tree signatures

### DIFF
--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -259,7 +259,7 @@ class MerkleTreeBatch {
     this.tree.length = this.length
     this.tree.byteLength = this.byteLength
     this.tree.fork = this.fork
-    this.tree.signature = this.signature
+    this.tree.signature = this.signature !== null ? unslab(this.signature) : null
   }
 
   seek (bytes, padding) {
@@ -429,7 +429,7 @@ module.exports = class MerkleTree {
     this.roots = roots
     this.length = roots.length ? totalSpan(roots) / 2 : 0
     this.byteLength = totalSize(roots)
-    this.signature = signature
+    this.signature = signature !== null ? unslab(signature) : null
     this.prologue = prologue
 
     this.storage = storage
@@ -438,15 +438,6 @@ module.exports = class MerkleTree {
     this.flushing = null
     this.truncated = false
     this.truncateTo = 0
-  }
-
-  get signature () {
-    return this._signature
-  }
-
-  set signature (signature) {
-    if (signature) signature = unslab(signature)
-    this._signature = signature
   }
 
   addNode (node) {

--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -440,6 +440,15 @@ module.exports = class MerkleTree {
     this.truncateTo = 0
   }
 
+  get signature () {
+    return this._signature
+  }
+
+  set signature (signature) {
+    if (signature) signature = unslab(signature)
+    this._signature = signature
+  }
+
   addNode (node) {
     if (node.size === 0 && b4a.equals(node.hash, BLANK_HASH)) node = blankNode(node.index)
     this.unflushed.set(node.index, node)

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -1599,6 +1599,21 @@ test('handshake is unslabbed', async function (t) {
   )
 })
 
+test('merkle-tree signature gets unslabbed', async function (t) {
+  const a = await create()
+  await a.append(['a'])
+
+  const b = await create(a.key)
+  replicate(a, b, t)
+  await b.get(0)
+
+  t.is(
+    b.core.tree.signature.buffer.byteLength,
+    64,
+    'Signature got unslabbed'
+  )
+})
+
 async function waitForRequestBlock (core) {
   while (true) {
     const reqBlock = core.replicator._inflight._requests.find(req => req && req.block)


### PR DESCRIPTION
Current behaviour is that the signatures retain whichever slab they come from (udx-slab, or file-system slab).

Note: opted for get/set semantics to have the logic lives in one place (so I can't forget any unslabbing, and to make it future proof)
