### PR TITLE
Unslab merkle-tree roots

### DIFF
--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -256,7 +256,6 @@ class MerkleTreeBatch {
       if (this.tree.flushing !== null) truncateMap(this.tree.flushing, this.ancestors)
     }
 
-    unslabNodes(this.roots)
     this.tree.roots = this.roots
 
     this.tree.length = this.length
@@ -460,6 +459,7 @@ module.exports = class MerkleTree {
     if (length === this.length) return batch
 
     const roots = await this.getRoots(length)
+    unslabNodes(roots)
 
     batch.roots = roots
     batch.length = length
@@ -676,7 +676,9 @@ module.exports = class MerkleTree {
       if (i < batch.roots.length && batch.roots[i].index === root) continue
 
       while (batch.roots.length > i) batch.roots.pop()
-      batch.roots.push(await this.get(root))
+      const node = await this.get(root)
+      unslabNodes([node])
+      batch.roots.push(node)
     }
 
     while (batch.roots.length > fullRoots.length) {

--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -671,8 +671,7 @@ module.exports = class MerkleTree {
       if (i < batch.roots.length && batch.roots[i].index === root) continue
 
       while (batch.roots.length > i) batch.roots.pop()
-      const node = unslabNode(await this.get(root))
-      batch.roots.push(node)
+      batch.roots.push(unslabNode(await this.get(root)))
     }
 
     while (batch.roots.length > fullRoots.length) {

--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -257,7 +257,6 @@ class MerkleTreeBatch {
     }
 
     this.tree.roots = this.roots
-
     this.tree.length = this.length
     this.tree.byteLength = this.byteLength
     this.tree.fork = this.fork
@@ -428,9 +427,7 @@ module.exports = class MerkleTree {
   constructor (storage, roots, fork, signature, prologue) {
     this.crypto = crypto
     this.fork = fork
-
     this.roots = roots
-
     this.length = roots.length ? totalSpan(roots) / 2 : 0
     this.byteLength = totalSize(roots)
     this.signature = signature

--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -183,7 +183,7 @@ class MerkleTreeBatch {
   }
 
   appendRoot (node, ite) {
-    unslabNodes([node])
+    node = unslabNode(node)
     this.hashCached = null
     this.upgraded = true
     this.length += ite.factor / 2
@@ -201,7 +201,7 @@ class MerkleTreeBatch {
         break
       }
 
-      const node = parentNode(this.tree.crypto, ite.parent(), a, b)
+      const node = unslabNode(parentNode(this.tree.crypto, ite.parent(), a, b))
       this.nodes.push(node)
       this.roots.pop()
       this.roots.pop()
@@ -429,7 +429,6 @@ module.exports = class MerkleTree {
     this.crypto = crypto
     this.fork = fork
 
-    unslabNodes(roots)
     this.roots = roots
 
     this.length = roots.length ? totalSpan(roots) / 2 : 0
@@ -458,8 +457,7 @@ module.exports = class MerkleTree {
     const batch = new MerkleTreeBatch(this)
     if (length === this.length) return batch
 
-    const roots = await this.getRoots(length)
-    unslabNodes(roots)
+    const roots = unslabNodes(await this.getRoots(length))
 
     batch.roots = roots
     batch.length = length
@@ -676,8 +674,7 @@ module.exports = class MerkleTree {
       if (i < batch.roots.length && batch.roots[i].index === root) continue
 
       while (batch.roots.length > i) batch.roots.pop()
-      const node = await this.get(root)
-      unslabNodes([node])
+      const node = unslabNode(await this.get(root))
       batch.roots.push(node)
     }
 
@@ -826,7 +823,7 @@ module.exports = class MerkleTree {
 
     const roots = []
     for (const index of flat.fullRoots(2 * length)) {
-      roots.push(await getStoredNode(storage, index, null, true))
+      roots.push(unslabNode(await getStoredNode(storage, index, null, true)))
     }
 
     return new MerkleTree(storage, roots, opts.fork || 0, opts.signature || null, opts.prologue || null)
@@ -1408,4 +1405,13 @@ function unslabNodes (nodes) {
   for (let i = 0; i < nodes.length; i++) {
     nodes[i].hash = unslabbed[i]
   }
+
+  return nodes
+}
+
+function unslabNode (node) {
+  if (node === null) return node
+
+  node.hash = unslab(node.hash)
+  return node
 }

--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -440,6 +440,22 @@ module.exports = class MerkleTree {
     this.truncateTo = 0
   }
 
+  get roots () {
+    return this._roots
+  }
+
+  set roots (roots) {
+    if (roots) { // 1 slab for all roots
+      const hashes = roots.map(r => r.hash)
+      const unslabbed = unslab.all(hashes)
+      for (let i = 0; i < roots.length; i++) {
+        roots[i].hash = unslabbed[i]
+      }
+    }
+
+    this._roots = roots
+  }
+
   addNode (node) {
     if (node.size === 0 && b4a.equals(node.hash, BLANK_HASH)) node = blankNode(node.index)
     this.unflushed.set(node.index, node)

--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -1391,16 +1391,12 @@ function getUnpaddedSize (node, padding, ite) {
 }
 
 function unslabNodes (nodes) {
-  for (const node of nodes) {
-    unslabNode(node)
-  }
-
+  for (const node of nodes) unslabNode(node)
   return nodes
 }
 
 function unslabNode (node) {
   if (node === null) return node
-
   node.hash = unslab(node.hash)
   return node
 }

--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -1391,15 +1391,8 @@ function getUnpaddedSize (node, padding, ite) {
 }
 
 function unslabNodes (nodes) {
-  const hashes = []
   for (const node of nodes) {
-    hashes.push(node.hash)
-  }
-
-  const unslabbed = unslab.all(hashes)
-
-  for (let i = 0; i < nodes.length; i++) {
-    nodes[i].hash = unslabbed[i]
+    unslabNode(node)
   }
 
   return nodes

--- a/lib/merkle-tree.js
+++ b/lib/merkle-tree.js
@@ -183,6 +183,7 @@ class MerkleTreeBatch {
   }
 
   appendRoot (node, ite) {
+    unslabNodes([node])
     this.hashCached = null
     this.upgraded = true
     this.length += ite.factor / 2
@@ -255,7 +256,9 @@ class MerkleTreeBatch {
       if (this.tree.flushing !== null) truncateMap(this.tree.flushing, this.ancestors)
     }
 
+    unslabNodes(this.roots)
     this.tree.roots = this.roots
+
     this.tree.length = this.length
     this.tree.byteLength = this.byteLength
     this.tree.fork = this.fork
@@ -426,7 +429,10 @@ module.exports = class MerkleTree {
   constructor (storage, roots, fork, signature, prologue) {
     this.crypto = crypto
     this.fork = fork
+
+    unslabNodes(roots)
     this.roots = roots
+
     this.length = roots.length ? totalSpan(roots) / 2 : 0
     this.byteLength = totalSize(roots)
     this.signature = signature
@@ -438,22 +444,6 @@ module.exports = class MerkleTree {
     this.flushing = null
     this.truncated = false
     this.truncateTo = 0
-  }
-
-  get roots () {
-    return this._roots
-  }
-
-  set roots (roots) {
-    if (roots) { // 1 slab for all roots
-      const hashes = roots.map(r => r.hash)
-      const unslabbed = unslab.all(hashes)
-      for (let i = 0; i < roots.length; i++) {
-        roots[i].hash = unslabbed[i]
-      }
-    }
-
-    this._roots = roots
   }
 
   addNode (node) {
@@ -1403,4 +1393,17 @@ async function generateProof (tree, block, hash, seek, upgrade) {
 
 function getUnpaddedSize (node, padding, ite) {
   return padding === 0 ? node.size : node.size - padding * (ite ? ite.countLeaves() : flat.countLeaves(node.index))
+}
+
+function unslabNodes (nodes) {
+  const hashes = []
+  for (const node of nodes) {
+    hashes.push(node.hash)
+  }
+
+  const unslabbed = unslab.all(hashes)
+
+  for (let i = 0; i < nodes.length; i++) {
+    nodes[i].hash = unslabbed[i]
+  }
 }

--- a/test/merkle-tree.js
+++ b/test/merkle-tree.js
@@ -602,7 +602,7 @@ test('checkout nodes in a batch', async t => {
   t.alike(nodes, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18, 19, 20, 21, 22, 24, 25, 26, 28])
 })
 
-test('roots get unslabbed in one slab', async function (t) {
+test('roots get unslabbed', async function (t) {
   const tree = await create()
 
   const b = tree.batch()
@@ -616,21 +616,23 @@ test('roots get unslabbed in one slab', async function (t) {
   t.is(tree.roots.length > 1, true, 'sanity check')
 
   const rootByteLength = 32
-  const nrRoots = 3
   const buffer = tree.roots[0].hash.buffer
 
   t.is(
     buffer.byteLength,
-    nrRoots * rootByteLength,
-    'unslabbed the roots, and put them all in the same slab'
+    rootByteLength,
+    'unslabbed the first root'
   )
-
-  // Sanity check
-  for (const root of tree.roots) {
-    if (root.hash.buffer !== buffer) {
-      t.fail('a root lives on a different slab')
-    }
-  }
+  t.is(
+    tree.roots[1].hash.buffer.byteLength,
+    rootByteLength,
+    'unslabbed the second root'
+  )
+  t.is(
+    tree.roots[2].hash.buffer.byteLength,
+    rootByteLength,
+    'unslabbed the third root'
+  )
 })
 
 test('buffer of cached nodes is copied to small slab', async function (t) {

--- a/test/merkle-tree.js
+++ b/test/merkle-tree.js
@@ -602,6 +602,37 @@ test('checkout nodes in a batch', async t => {
   t.alike(nodes, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 16, 17, 18, 19, 20, 21, 22, 24, 25, 26, 28])
 })
 
+test('roots get unslabbed in one slab', async function (t) {
+  const tree = await create()
+
+  const b = tree.batch()
+
+  for (let i = 0; i < 100; i++) {
+    b.append(b4a.from([i]))
+  }
+
+  b.commit()
+
+  t.is(tree.roots.length > 1, true, 'sanity check')
+
+  const rootByteLength = 32
+  const nrRoots = 3
+  const buffer = tree.roots[0].hash.buffer
+
+  t.is(
+    buffer.byteLength,
+    nrRoots * rootByteLength,
+    'unslabbed the roots, and put them all in the same slab'
+  )
+
+  // Sanity check
+  for (const root of tree.roots) {
+    if (root.hash.buffer !== buffer) {
+      t.fail('a root lives on a different slab')
+    }
+  }
+})
+
 test('buffer of cached nodes is copied to small slab', async function (t) {
   // RAM does not use slab-allocated memory,
   // so we need to us random-access-file to reproduce this issue


### PR DESCRIPTION
Current behaviour is that they retain the slab they come from (like the 68kb udx slab)

Note: the unslabbing could be optimised to avoid iterating twice over the roots, but I think the difference would be irrelevant (if even noticeable)