### PR TITLE
Unslab manifest

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -697,6 +697,8 @@ module.exports = class Core {
       }
     }
 
+    manifest = Verifier.createManifest(manifest) // To unslab
+
     const verifier = this.verifier || new Verifier(this.header.key, manifest, { crypto: this.crypto, legacy: this._legacy })
 
     if (!verifier.verify(batch, batch.signature)) {

--- a/lib/core.js
+++ b/lib/core.js
@@ -163,6 +163,9 @@ module.exports = class Core {
       while (bitfield.get(header.hints.contiguousLength)) header.hints.contiguousLength++
     }
 
+    // to unslab
+    if (header.manifest) header.manifest = Verifier.createManifest(header.manifest)
+
     const verifier = header.manifest ? new Verifier(header.key, header.manifest, { crypto, legacy }) : null
 
     for (const e of entries) {

--- a/lib/verifier.js
+++ b/lib/verifier.js
@@ -3,6 +3,7 @@ const b4a = require('b4a')
 const c = require('compact-encoding')
 const flat = require('flat-tree')
 const { BAD_ARGUMENT } = require('hypercore-errors')
+const unslab = require('unslab')
 
 const m = require('./messages')
 const multisig = require('./multisig')
@@ -201,7 +202,9 @@ module.exports = class Verifier {
       if (!(b4a.isBuffer(inp.prologue.hash) && inp.prologue.hash.byteLength === 32) || !(inp.prologue.length >= 0)) {
         throw BAD_ARGUMENT('Invalid prologue')
       }
+
       manifest.prologue = inp.prologue
+      manifest.prologue.hash = unslab(manifest.prologue.hash)
     }
 
     return manifest
@@ -274,8 +277,8 @@ function parseSigner (signer) {
   validateSigner(signer)
   return {
     signature: 'ed25519',
-    namespace: signer.namespace || caps.DEFAULT_NAMESPACE,
-    publicKey: signer.publicKey
+    namespace: unslab(signer.namespace || caps.DEFAULT_NAMESPACE),
+    publicKey: unslab(signer.publicKey)
   }
 }
 


### PR DESCRIPTION
Current behaviour is that it retains buffers through `signer.publicKey` and `signer.namespace` (sometimes buffers of multiple Mb if they come from UDX).

This fixes the leak on the code paths I can reproduce.

Warning: I'm not sure it's safe to call `Verifier.createManifest` on passed-in manifests (for example, it will throw for non-blake2b hashes) 