### PR TITLE
Bugfix: edge cases where req is null

### DIFF
--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -1108,6 +1108,8 @@ class Peer {
       if (h.inflight.length > 0) continue
 
       const req = this._makeRequest(false, h.priority, index + 1)
+      if (req === null) continue
+
       const nodes = flatTree.depth(s.seeker.start + s.seeker.end - 1)
 
       req.hash = { index: 2 * index, nodes }
@@ -1299,6 +1301,7 @@ class Peer {
       if (this._remoteHasBlock(index) === false) continue
 
       const req = this._makeRequest(false, 0, 0)
+      if (req === null) continue
 
       req.hash = { index: 2 * index, nodes: f.batch.want.nodes }
 


### PR DESCRIPTION
https://github.com/holepunchto/hypercore/commit/7efbb35e81bb1eaf88f05fce6cbf43f424106edb added a case where `_makeRequest` returns null, but not all consumers take that into account.

I think it can occur for 2 other methods, but unsure what the behaviour should be if req is null:

requestManifest https://github.com/holepunchto/hypercore/blob/a2c00faaf3be0774c57c723b229d0fbd07269f6d/lib/replicator.js#L1055-L1058

requestForkProof https://github.com/holepunchto/hypercore/blob/a2c00faaf3be0774c57c723b229d0fbd07269f6d/lib/replicator.js#L1276-L1284