### PR TITLE
rm unneeded null check

### DIFF
--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -1301,7 +1301,6 @@ class Peer {
       if (this._remoteHasBlock(index) === false) continue
 
       const req = this._makeRequest(false, 0, 0)
-      if (req === null) continue
 
       req.hash = { index: 2 * index, nodes: f.batch.want.nodes }
 


### PR DESCRIPTION
Removes an unneeded null check in https://github.com/holepunchto/hypercore/pull/547

It should never return 0, because minLength is set to 0 (the newly added null-path returns null when the minLength is smaller than the remoteLength, which is impossible for 0)