### PR TITLE
Unslab userdata values and all header buffers

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -100,6 +100,7 @@ module.exports = class Core {
       }
 
       const keyPair = opts.keyPair || (opts.key ? null : crypto.keyPair())
+
       const defaultManifest = !opts.manifest && (!!opts.compat || !opts.key || !!(keyPair && b4a.equals(opts.key, keyPair.publicKey)))
       const manifest = defaultManifest ? Verifier.defaultSignerManifest(opts.key || keyPair.publicKey) : Verifier.createManifest(opts.manifest)
 
@@ -121,6 +122,10 @@ module.exports = class Core {
         }
       }
 
+      if (header.keyPair && !header.keyPair.secretKey) {
+        header.keyPair.secretKey = null
+      }
+
       await flushHeader(oplog, bigHeader, header)
     } else if (header.external) {
       header = await bigHeader.load(header.external)
@@ -131,8 +136,10 @@ module.exports = class Core {
     header.tree.rootHash = unslab(header.tree.rootHash)
     header.tree.signature = unslab(header.tree.signature)
 
-    if (header.keyPair?.publicKey) header.keyPair.publicKey = unslab(header.keyPair.publicKey)
-    if (header.keyPair?.secretKey) header.keyPair.secretKey = unslab(header.keyPair.secretKey)
+    if (header.keyPair) {
+      header.keyPair.publicKey = unslab(header.keyPair.publicKey)
+      header.keyPair.secretKey = unslab(header.keyPair.secretKey)
+    }
 
     if (opts.manifest) {
       // if we provide a manifest and no key, verify that the stored key is the same

--- a/lib/core.js
+++ b/lib/core.js
@@ -131,6 +131,9 @@ module.exports = class Core {
     header.tree.rootHash = unslab(header.tree.rootHash)
     header.tree.signature = unslab(header.tree.signature)
 
+    if (header.keyPair?.publicKey) header.keyPair.publicKey = unslab(header.keyPair.publicKey)
+    if (header.keyPair?.secretKey) header.keyPair.secretKey = unslab(header.keyPair.secretKey)
+
     if (opts.manifest) {
       // if we provide a manifest and no key, verify that the stored key is the same
       if (!opts.key && !Verifier.isValidManifest(header.key, Verifier.createManifest(opts.manifest))) {
@@ -202,6 +205,10 @@ module.exports = class Core {
         header.tree.rootHash = tree.hash()
         header.tree.signature = tree.signature
       }
+    }
+
+    for (const entry of header.userData) {
+      entry.value = unslab(entry.value)
     }
 
     return new this(header, compat, crypto, oplog, bigHeader, tree, blocks, bitfield, verifier, opts.sessions || [], legacy, opts.globalCache || null, opts.onupdate || noop, opts.onconflict || noop)
@@ -1022,6 +1029,8 @@ function addReorgHint (list, tree, batch) {
 }
 
 function updateUserData (list, key, value) {
+  value = unslab(value)
+
   for (let i = 0; i < list.length; i++) {
     if (list[i].key === key) {
       if (value) list[i].value = value

--- a/lib/core.js
+++ b/lib/core.js
@@ -107,7 +107,7 @@ module.exports = class Core {
         external: null,
         key: opts.key || (compat ? manifest.signers[0].publicKey : Verifier.manifestHash(manifest)),
         manifest,
-        keyPair,
+        keyPair: keyPair ? { publicKey: keyPair.publicKey, secretKey: keyPair.secretKey || null } : null,
         userData: [],
         tree: {
           fork: 0,
@@ -119,10 +119,6 @@ module.exports = class Core {
           reorgs: [],
           contiguousLength: 0
         }
-      }
-
-      if (header.keyPair && !header.keyPair.secretKey) {
-        header.keyPair.secretKey = null
       }
 
       await flushHeader(oplog, bigHeader, header)

--- a/lib/core.js
+++ b/lib/core.js
@@ -100,7 +100,6 @@ module.exports = class Core {
       }
 
       const keyPair = opts.keyPair || (opts.key ? null : crypto.keyPair())
-
       const defaultManifest = !opts.manifest && (!!opts.compat || !opts.key || !!(keyPair && b4a.equals(opts.key, keyPair.publicKey)))
       const manifest = defaultManifest ? Verifier.defaultSignerManifest(opts.key || keyPair.publicKey) : Verifier.createManifest(opts.manifest)
 

--- a/test/core.js
+++ b/test/core.js
@@ -126,6 +126,29 @@ test('core - user data', async function (t) {
   t.alike(coreReopen.header.userData, [{ key: 'hej', value: b4a.from('world') }])
 })
 
+test('core - header does not retain slabs', async function (t) {
+  const { core, reopen } = await create()
+  await core.userData('hello', b4a.from('world'))
+
+  t.is(core.header.key.buffer.byteLength, 32, 'unslabbed key')
+  t.is(core.header.keyPair.publicKey.buffer.byteLength, 32, 'unslabbed public key')
+  t.is(core.header.keyPair.secretKey.buffer.byteLength, 64, 'unslabbed private key')
+  t.is(core.header.manifest.signers[0].namespace.buffer.byteLength, 32, 'unslabbed signers namespace')
+  t.is(core.header.manifest.signers[0].publicKey.buffer.byteLength, 32, 'unslabbed signers publicKey')
+
+  t.is(core.header.userData[0].value.buffer.byteLength, 5, 'unslabbed the userdata value')
+
+  // check the different code path when re-opening
+  const coreReopen = await reopen()
+
+  t.is(coreReopen.header.key.buffer.byteLength, 32, 'reopen unslabbed key')
+  t.is(coreReopen.header.keyPair.publicKey.buffer.byteLength, 32, 'reopen unslabbed public key')
+  t.is(coreReopen.header.keyPair.secretKey.buffer.byteLength, 64, 'reopen unslabbed secret key')
+  t.is(coreReopen.header.manifest.signers[0].namespace.buffer.byteLength, 32, 'reopen unslabbed signers namespace')
+  t.is(coreReopen.header.manifest.signers[0].publicKey.buffer.byteLength, 32, 'reopen unslabbed signers publicKey')
+  t.is(coreReopen.header.userData[0].value.buffer.byteLength, 5, 'reopen unslabbed the userdata value')
+})
+
 test('core - verify', async function (t) {
   const { core } = await create()
   const { core: clone } = await create({ keyPair: { publicKey: core.header.keyPair.publicKey } })


### PR DESCRIPTION
Note: the userdata value is set through (at least) 2 code paths:
- through `updateUserData()`
- through the `header` value of `oplog.open()` (in `resume()`)
So I unslabbed it in both

