### PR TITLE
Track replicator message stats

### DIFF
--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -359,9 +359,15 @@ class Peer {
     this.wireExtension = this.channel.messages[9]
 
     // Same stats as replicator, but for this specific peer
-    this.stats = {}
-    for (const statName of Object.keys(this.replicator.stats)) {
-      this.stats[statName] = 0
+    this.stats = {
+      wireSync: { tx: 0, rx: 0 },
+      wireRequest: { tx: 0, rx: 0 },
+      wireCancel: { tx: 0, rx: 0 },
+      wireData: { tx: 0, rx: 0 },
+      wireWant: { tx: 0, rx: 0 },
+      wireBitfield: { tx: 0, rx: 0 },
+      wireRange: { tx: 0, rx: 0 },
+      wireExtension: { tx: 0, rx: 0 }
     }
 
     this.receiverQueue = new ReceiverQueue()
@@ -413,18 +419,6 @@ class Peer {
     return this.remoteBitfield.findFirst(false, this._remoteContiguousLength)
   }
 
-  incrementReceived (wireMessageName) {
-    const name = `${wireMessageName}Received`
-    this.stats[name]++
-    this.replicator.stats[name]++
-  }
-
-  incrementTransmitted (wireMessageName) {
-    const name = `${wireMessageName}Transmitted`
-    this.stats[name]++
-    this.replicator.stats[name]++
-  }
-
   getMaxInflight () {
     const stream = this.stream.rawStream
     if (!stream.udx) return Math.min(this.inflightRange[1], this.inflightRange[0] * 3)
@@ -464,12 +458,12 @@ class Peer {
       start,
       length
     })
-    this.incrementTransmitted('wireRange')
+    incrementTx(this.stats.wireRange, this.replicator.stats.wireRange)
   }
 
   extension (name, message) {
     this.wireExtension.send({ name: name === this.lastExtensionSent ? '' : name, message })
-    this.incrementTransmitted('wireExtension')
+    incrementTx(this.stats.wireExtension, this.replicator.stats.wireExtension)
     this.lastExtensionSent = name
   }
 
@@ -501,7 +495,7 @@ class Peer {
       downloading: this.replicator.isDownloading(),
       hasManifest: !!this.core.header.manifest && this.core.compat === false
     })
-    this.incrementTransmitted('wireSync')
+    incrementTx(this.stats.wireSync, this.replicator.stats.wireSync)
   }
 
   onopen ({ seeks, capability }) {
@@ -751,7 +745,7 @@ class Peer {
       if (msg.manifest && this.core.header.manifest) {
         const manifest = this.core.header.manifest
         this.wireData.send({ request: msg.id, fork: this.core.tree.fork, block: null, hash: null, seek: null, upgrade: null, manifest })
-        this.incrementTransmitted('wireData')
+        incrementTx(this.stats.wireData, this.replicator.stats.wireData)
         return
       }
 
@@ -772,7 +766,7 @@ class Peer {
       upgrade: proof.upgrade,
       manifest: proof.manifest
     })
-    this.incrementTransmitted('wireData')
+    incrementTx(this.stats.wireData, this.replicator.stats.wireData)
   }
 
   _cancelRequest (req) {
@@ -790,7 +784,7 @@ class Peer {
     if (this.roundtripQueue === null) this.roundtripQueue = new RoundtripQueue()
     this.roundtripQueue.add(req.id)
     this.wireCancel.send({ request: req.id })
-    this.incrementTransmitted('wireCancel')
+    incrementTx(this.stats.wireCancel, this.replicator.stats.wireCancel)
   }
 
   _checkIfConflict () {
@@ -811,7 +805,7 @@ class Peer {
       }
     })
 
-    this.incrementTransmitted('wireRequest')
+    incrementTx(this.stats.wireRequest, this.replicator.stats.wireRequest)
   }
 
   async ondata (data) {
@@ -1354,7 +1348,7 @@ class Peer {
         start: i * DEFAULT_SEGMENT_SIZE,
         length: DEFAULT_SEGMENT_SIZE
       })
-      this.incrementTransmitted('wireWant')
+      incrementTx(this.stats.wireWant, this.replicator.stats.wireWant)
     }
   }
 
@@ -1398,7 +1392,7 @@ class Peer {
     this.tracer.trace('send', req)
 
     this.wireRequest.send(req)
-    this.incrementTransmitted('wireRequest')
+    incrementTx(this.stats.wireRequest, this.replicator.stats.wireRequest)
   }
 }
 
@@ -1433,23 +1427,16 @@ module.exports = class Replicator {
     this.inflightRange = inflightRange || DEFAULT_MAX_INFLIGHT
 
     // Note: nodata and unwant not currently tracked
+    // tx = transmitted, rx = received
     this.stats = {
-      wireSyncReceived: 0,
-      wireSyncTransmitted: 0,
-      wireRequestReceived: 0,
-      wireRequestTransmitted: 0,
-      wireCancelReceived: 0,
-      wireCancelTransmitted: 0,
-      wireDataReceived: 0,
-      wireDataTransmitted: 0,
-      wireWantReceived: 0,
-      wireWantTransmitted: 0,
-      wireBitfieldReceived: 0,
-      wireBitfieldTransmitted: 0,
-      wireRangeReceived: 0,
-      wireRangeTransmitted: 0,
-      wireExtensionReceived: 0,
-      wireExtensionTransmitted: 0
+      wireSync: { tx: 0, rx: 0 },
+      wireRequest: { tx: 0, rx: 0 },
+      wireCancel: { tx: 0, rx: 0 },
+      wireData: { tx: 0, rx: 0 },
+      wireWant: { tx: 0, rx: 0 },
+      wireBitfield: { tx: 0, rx: 0 },
+      wireRange: { tx: 0, rx: 0 },
+      wireExtension: { tx: 0, rx: 0 }
     }
 
     this._attached = new Set()
@@ -2053,7 +2040,7 @@ module.exports = class Replicator {
         start: 0,
         length: contig
       })
-      peer.incrementTransmitted('wireRange')
+      incrementTx(peer.stats.wireRange, this.stats.wireRange)
       return
     }
 
@@ -2063,7 +2050,7 @@ module.exports = class Replicator {
 
     for (const msg of this.core.bitfield.want(start, length)) {
       peer.wireBitfield.send(msg)
-      peer.incrementTransmitted('wireBitfield')
+      incrementTx(peer.stats.wireBitfield, this.stats.wireBitfield)
     }
 
     peer.protomux.uncork()
@@ -2437,22 +2424,22 @@ function onwiredrain (c) {
 }
 
 function onwiresync (m, c) {
-  c.userData.incrementReceived('wireSync')
+  incrementRx(c.userData.stats.wireSync, c.userData.replicator.stats.wireSync)
   return c.userData.onsync(m)
 }
 
 function onwirerequest (m, c) {
-  c.userData.incrementReceived('wireRequest')
+  incrementRx(c.userData.stats.wireRequest, c.userData.replicator.stats.wireRequest)
   return c.userData.onrequest(m)
 }
 
 function onwirecancel (m, c) {
-  c.userData.incrementReceived('wireCancel')
+  incrementRx(c.userData.stats.wireCancel, c.userData.replicator.stats.wireCancel)
   return c.userData.oncancel(m)
 }
 
 function onwiredata (m, c) {
-  c.userData.incrementReceived('wireData')
+  incrementRx(c.userData.stats.wireData, c.userData.replicator.stats.wireData)
   return c.userData.ondata(m)
 }
 
@@ -2461,7 +2448,7 @@ function onwirenodata (m, c) {
 }
 
 function onwirewant (m, c) {
-  c.userData.incrementReceived('wireWant')
+  incrementRx(c.userData.stats.wireWant, c.userData.replicator.stats.wireWant)
   return c.userData.onwant(m)
 }
 
@@ -2470,17 +2457,17 @@ function onwireunwant (m, c) {
 }
 
 function onwirebitfield (m, c) {
-  c.userData.incrementReceived('wireBitfield')
+  incrementRx(c.userData.stats.wireBitfield, c.userData.replicator.stats.wireBitfield)
   return c.userData.onbitfield(m)
 }
 
 function onwirerange (m, c) {
-  c.userData.incrementReceived('wireRange')
+  incrementRx(c.userData.stats.wireRange, c.userData.replicator.stats.wireRange)
   return c.userData.onrange(m)
 }
 
 function onwireextension (m, c) {
-  c.userData.incrementReceived('wireExtension')
+  incrementRx(c.userData.stats.wireExtension, c.userData.replicator.stats.wireExtension)
   return c.userData.onextension(m)
 }
 
@@ -2494,4 +2481,14 @@ function isBlockRequest (req) {
 
 function isUpgradeRequest (req) {
   return req !== null && req.upgrade !== null
+}
+
+function incrementTx (stats1, stats2) {
+  stats1.tx++
+  stats2.tx++
+}
+
+function incrementRx (stats1, stats2) {
+  stats1.rx++
+  stats2.rx++
 }

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -358,6 +358,12 @@ class Peer {
     this.wireRange = this.channel.messages[8]
     this.wireExtension = this.channel.messages[9]
 
+    // Same stats as replicator, but for this specific peer
+    this.stats = {}
+    for (const statName of Object.keys(this.replicator.stats)) {
+      this.stats[statName] = 0
+    }
+
     this.receiverQueue = new ReceiverQueue()
     this.receiverBusy = false
 
@@ -407,6 +413,18 @@ class Peer {
     return this.remoteBitfield.findFirst(false, this._remoteContiguousLength)
   }
 
+  incrementReceived (wireMessageName) {
+    const name = `${wireMessageName}Received`
+    this.stats[name]++
+    this.replicator.stats[name]++
+  }
+
+  incrementTransmitted (wireMessageName) {
+    const name = `${wireMessageName}Transmitted`
+    this.stats[name]++
+    this.replicator.stats[name]++
+  }
+
   getMaxInflight () {
     const stream = this.stream.rawStream
     if (!stream.udx) return Math.min(this.inflightRange[1], this.inflightRange[0] * 3)
@@ -446,10 +464,12 @@ class Peer {
       start,
       length
     })
+    this.incrementTransmitted('wireRange')
   }
 
   extension (name, message) {
     this.wireExtension.send({ name: name === this.lastExtensionSent ? '' : name, message })
+    this.incrementTransmitted('wireExtension')
     this.lastExtensionSent = name
   }
 
@@ -481,6 +501,7 @@ class Peer {
       downloading: this.replicator.isDownloading(),
       hasManifest: !!this.core.header.manifest && this.core.compat === false
     })
+    this.incrementTransmitted('wireSync')
   }
 
   onopen ({ seeks, capability }) {
@@ -730,6 +751,7 @@ class Peer {
       if (msg.manifest && this.core.header.manifest) {
         const manifest = this.core.header.manifest
         this.wireData.send({ request: msg.id, fork: this.core.tree.fork, block: null, hash: null, seek: null, upgrade: null, manifest })
+        this.incrementTransmitted('wireData')
         return
       }
 
@@ -750,6 +772,7 @@ class Peer {
       upgrade: proof.upgrade,
       manifest: proof.manifest
     })
+    this.incrementTransmitted('wireData')
   }
 
   _cancelRequest (req) {
@@ -767,6 +790,7 @@ class Peer {
     if (this.roundtripQueue === null) this.roundtripQueue = new RoundtripQueue()
     this.roundtripQueue.add(req.id)
     this.wireCancel.send({ request: req.id })
+    this.incrementTransmitted('wireCancel')
   }
 
   _checkIfConflict () {
@@ -786,6 +810,8 @@ class Peer {
         length
       }
     })
+
+    this.incrementTransmitted('wireRequest')
   }
 
   async ondata (data) {
@@ -1328,6 +1354,7 @@ class Peer {
         start: i * DEFAULT_SEGMENT_SIZE,
         length: DEFAULT_SEGMENT_SIZE
       })
+      this.incrementTransmitted('wireWant')
     }
   }
 
@@ -1371,6 +1398,7 @@ class Peer {
     this.tracer.trace('send', req)
 
     this.wireRequest.send(req)
+    this.incrementTransmitted('wireRequest')
   }
 }
 
@@ -1403,6 +1431,26 @@ module.exports = class Replicator {
     this.activeSessions = 0
 
     this.inflightRange = inflightRange || DEFAULT_MAX_INFLIGHT
+
+    // Note: nodata and unwant not currently tracked
+    this.stats = {
+      wireSyncReceived: 0,
+      wireSyncTransmitted: 0,
+      wireRequestReceived: 0,
+      wireRequestTransmitted: 0,
+      wireCancelReceived: 0,
+      wireCancelTransmitted: 0,
+      wireDataReceived: 0,
+      wireDataTransmitted: 0,
+      wireWantReceived: 0,
+      wireWantTransmitted: 0,
+      wireBitfieldReceived: 0,
+      wireBitfieldTransmitted: 0,
+      wireRangeReceived: 0,
+      wireRangeTransmitted: 0,
+      wireExtensionReceived: 0,
+      wireExtensionTransmitted: 0
+    }
 
     this._attached = new Set()
     this._inflight = new InflightTracker()
@@ -2005,6 +2053,7 @@ module.exports = class Replicator {
         start: 0,
         length: contig
       })
+      peer.incrementTransmitted('wireRange')
       return
     }
 
@@ -2014,6 +2063,7 @@ module.exports = class Replicator {
 
     for (const msg of this.core.bitfield.want(start, length)) {
       peer.wireBitfield.send(msg)
+      peer.incrementTransmitted('wireBitfield')
     }
 
     peer.protomux.uncork()
@@ -2387,18 +2437,22 @@ function onwiredrain (c) {
 }
 
 function onwiresync (m, c) {
+  c.userData.incrementReceived('wireSync')
   return c.userData.onsync(m)
 }
 
 function onwirerequest (m, c) {
+  c.userData.incrementReceived('wireRequest')
   return c.userData.onrequest(m)
 }
 
 function onwirecancel (m, c) {
+  c.userData.incrementReceived('wireCancel')
   return c.userData.oncancel(m)
 }
 
 function onwiredata (m, c) {
+  c.userData.incrementReceived('wireData')
   return c.userData.ondata(m)
 }
 
@@ -2407,6 +2461,7 @@ function onwirenodata (m, c) {
 }
 
 function onwirewant (m, c) {
+  c.userData.incrementReceived('wireWant')
   return c.userData.onwant(m)
 }
 
@@ -2415,14 +2470,17 @@ function onwireunwant (m, c) {
 }
 
 function onwirebitfield (m, c) {
+  c.userData.incrementReceived('wireBitfield')
   return c.userData.onbitfield(m)
 }
 
 function onwirerange (m, c) {
+  c.userData.incrementReceived('wireRange')
   return c.userData.onrange(m)
 }
 
 function onwireextension (m, c) {
+  c.userData.incrementReceived('wireExtension')
   return c.userData.onextension(m)
 }
 

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -19,6 +19,7 @@ test('basic replication', async function (t) {
   replicate(a, b, t)
 
   const r = b.download({ start: 0, end: a.length })
+
   await r.done()
 
   t.is(d, 5)

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -31,9 +31,6 @@ test('basic replication stats', async function (t) {
 
   const b = await create(a.key)
 
-  let d = 0
-  b.on('download', () => d++)
-
   const aStats = a.replicator.stats
   const bStats = b.replicator.stats
 

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -35,25 +35,25 @@ test('basic replication stats', async function (t) {
   const aStats = a.replicator.stats
   const bStats = b.replicator.stats
 
-  t.is(aStats.wireSyncReceived, 0, 'wireSync init 0')
-  t.is(aStats.wireSyncTransmitted, 0, 'wireSync init 0')
-  t.is(aStats.wireRequestReceived, 0, 'wireRequests init 0')
-  t.is(aStats.wireRequestTransmitted, 0, 'wireRequests init 0')
-  t.is(aStats.wireDataReceived, 0, 'wireData init 0')
-  t.is(aStats.wireDataTransmitted, 0, 'wireData init 0')
-  t.is(aStats.wireWantReceived, 0, 'wireWant init 0')
-  t.is(aStats.wireWantTransmitted, 0, 'wireWant init 0')
-  t.is(aStats.wireBitfieldReceived, 0, 'wireBitfield init 0')
-  t.is(aStats.wireBitfieldTransmitted, 0, 'wireBitfield init 0')
-  t.is(aStats.wireRangeReceived, 0, 'wireRange init 0')
-  t.is(aStats.wireRangeTransmitted, 0, 'wireRange init 0')
-  t.is(aStats.wireExtensionReceived, 0, 'wireExtension init 0')
-  t.is(aStats.wireExtensionTransmitted, 0, 'wireExtension init 0')
-  t.is(aStats.wireCancelReceived, 0, 'wireCancel init 0')
-  t.is(aStats.wireCancelTransmitted, 0, 'wireCancel init 0')
+  t.is(aStats.wireSync.rx, 0, 'wireSync init 0')
+  t.is(aStats.wireSync.tx, 0, 'wireSync init 0')
+  t.is(aStats.wireRequest.rx, 0, 'wireRequests init 0')
+  t.is(aStats.wireRequest.tx, 0, 'wireRequests init 0')
+  t.is(aStats.wireData.rx, 0, 'wireData init 0')
+  t.is(aStats.wireData.tx, 0, 'wireData init 0')
+  t.is(aStats.wireWant.rx, 0, 'wireWant init 0')
+  t.is(aStats.wireWant.tx, 0, 'wireWant init 0')
+  t.is(aStats.wireBitfield.rx, 0, 'wireBitfield init 0')
+  t.is(aStats.wireBitfield.tx, 0, 'wireBitfield init 0')
+  t.is(aStats.wireRange.rx, 0, 'wireRange init 0')
+  t.is(aStats.wireRange.tx, 0, 'wireRange init 0')
+  t.is(aStats.wireExtension.rx, 0, 'wireExtension init 0')
+  t.is(aStats.wireExtension.tx, 0, 'wireExtension init 0')
+  t.is(aStats.wireCancel.rx, 0, 'wireCancel init 0')
+  t.is(aStats.wireCancel.tx, 0, 'wireCancel init 0')
 
   const initStatsLength = [...Object.keys(aStats)].length
-  t.is(initStatsLength, 16, 'Expected amount of stats')
+  t.is(initStatsLength, 8, 'Expected amount of stats')
 
   replicate(a, b, t)
 
@@ -65,20 +65,20 @@ test('basic replication stats', async function (t) {
   const aPeerStats = a.replicator.peers[0].stats
   t.alike(aPeerStats, aStats, 'same stats for peer as entire replicator (when there is only 1 peer)')
 
-  t.ok(aStats.wireSyncReceived > 0, 'wiresync incremented')
-  t.is(aStats.wireSyncReceived, bStats.wireSyncTransmitted, 'wireSync received == transmitted')
+  t.ok(aStats.wireSync.rx > 0, 'wiresync incremented')
+  t.is(aStats.wireSync.rx, bStats.wireSync.tx, 'wireSync received == transmitted')
 
-  t.ok(aStats.wireRequestReceived > 0, 'wireRequests incremented')
-  t.is(aStats.wireRequestReceived, bStats.wireRequestTransmitted, 'wireRequests received == transmitted')
+  t.ok(aStats.wireRequest.rx > 0, 'wireRequests incremented')
+  t.is(aStats.wireRequest.rx, bStats.wireRequest.tx, 'wireRequests received == transmitted')
 
-  t.ok(bStats.wireDataReceived > 0, 'wireRequests incremented')
-  t.is(aStats.wireDataTransmitted, bStats.wireDataReceived, 'wireData received == transmitted')
+  t.ok(bStats.wireData.rx > 0, 'wireRequests incremented')
+  t.is(aStats.wireData.tx, bStats.wireData.rx, 'wireData received == transmitted')
 
-  t.ok(aStats.wireWantReceived > 0, 'wireWant incremented')
-  t.is(bStats.wireWantTransmitted, aStats.wireWantReceived, 'wireWant received == transmitted')
+  t.ok(aStats.wireWant.rx > 0, 'wireWant incremented')
+  t.is(bStats.wireWant.tx, aStats.wireWant.rx, 'wireWant received == transmitted')
 
-  t.ok(bStats.wireRangeReceived > 0, 'wireRange incremented')
-  t.is(aStats.wireRangeTransmitted, bStats.wireRangeReceived, 'wireRange received == transmitted')
+  t.ok(bStats.wireRange.rx > 0, 'wireRange incremented')
+  t.is(aStats.wireRange.tx, bStats.wireRange.rx, 'wireRange received == transmitted')
 
   // extension messages
   const aExt = a.registerExtension('test-extension', {
@@ -86,8 +86,8 @@ test('basic replication stats', async function (t) {
   })
   aExt.send('hello', a.peers[0])
   await new Promise(resolve => setImmediate(resolve))
-  t.ok(bStats.wireExtensionReceived > 0, 'extension incremented')
-  t.is(aStats.wireExtensionTransmitted, bStats.wireExtensionReceived, 'extension received == transmitted')
+  t.ok(bStats.wireExtension.rx > 0, 'extension incremented')
+  t.is(aStats.wireExtension.tx, bStats.wireExtension.rx, 'extension received == transmitted')
 
   // bitfield messages
   await b.clear(1)
@@ -96,8 +96,8 @@ test('basic replication stats', async function (t) {
   c.get(1).catch(() => {})
   await new Promise(resolve => setImmediate(resolve))
   const cStats = c.replicator.stats
-  t.ok(cStats.wireBitfieldReceived > 0, 'bitfield incremented')
-  t.is(bStats.wireBitfieldTransmitted, cStats.wireBitfieldReceived, 'bitfield received == transmitted')
+  t.ok(cStats.wireBitfield.rx > 0, 'bitfield incremented')
+  t.is(bStats.wireBitfield.tx, cStats.wireBitfield.rx, 'bitfield received == transmitted')
 
   t.is(initStatsLength, [...Object.keys(aStats)].length, 'No stats were dynamically added')
 })
@@ -1339,8 +1339,8 @@ test('cancel block', async function (t) {
   await a.close()
   await b.close()
 
-  t.ok(a.replicator.stats.wireCancelReceived > 0, 'wireCancel stats incremented')
-  t.is(a.replicator.stats.wireCancelReceived, b.replicator.stats.wireCancelTransmitted, 'wireCancel stats consistent')
+  t.ok(a.replicator.stats.wireCancel.rx > 0, 'wireCancel stats incremented')
+  t.is(a.replicator.stats.wireCancel.rx, b.replicator.stats.wireCancel.tx, 'wireCancel stats consistent')
 })
 
 test('try cancel block from a different session', async function (t) {

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -52,6 +52,9 @@ test('basic replication stats', async function (t) {
   t.is(aStats.wireCancelReceived, 0, 'wireCancel init 0')
   t.is(aStats.wireCancelTransmitted, 0, 'wireCancel init 0')
 
+  const initStatsLength = [...Object.keys(aStats)].length
+  t.is(initStatsLength, 16, 'Expected amount of stats')
+
   replicate(a, b, t)
 
   b.get(10).catch(() => {}) // does not exist (for want messages0)
@@ -95,6 +98,8 @@ test('basic replication stats', async function (t) {
   const cStats = c.replicator.stats
   t.ok(cStats.wireBitfieldReceived > 0, 'bitfield incremented')
   t.is(bStats.wireBitfieldTransmitted, cStats.wireBitfieldReceived, 'bitfield received == transmitted')
+
+  t.is(initStatsLength, [...Object.keys(aStats)].length, 'No stats were dynamically added')
 })
 
 test('basic downloading is set immediately after ready', function (t) {

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -660,7 +660,6 @@ test('destroying a stream and re-replicating works', async function (t) {
   s2.destroy()
 })
 
-// TODO: wireWant here
 test('replicate discrete range', async function (t) {
   const a = await create()
 


### PR DESCRIPTION
This PR adds support for tracking stats about the most relevant hypercore-messages, at both core and peer level. For each message-type, it tracks the amount of transmitted and received messages.

Note: I found no clean way of intercepting calls when writing messages, so the transmission counter is incremented explicitly each time a message is sent, which for certain message types is in more than 1 place in the code. I think it's fine, because there aren't many places where we write messages, but it isn't ideal.

<strike>The guarantee is that all stats are defined at the moment the replicator/peer is created (with initial value 0). Stats are never added dynamically. I did introduce some dynamicism in the code, through `incrementReceived` and `incrementTransmitted`, to simplify the code and to help protect me from typos. (The test makes ~sure that we don't accidentally introduce dynamicism due to a typo.)</strike>

Note: nodata and uwnant messages are not tracked, because I could find no way of generating those messages in a test (the current tests don't seem to hit those paths)
