### PR TITLE
Add blocks/bytes uploaded/downloaded stats

### DIFF
--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -367,7 +367,11 @@ class Peer {
       wireWant: { tx: 0, rx: 0 },
       wireBitfield: { tx: 0, rx: 0 },
       wireRange: { tx: 0, rx: 0 },
-      wireExtension: { tx: 0, rx: 0 }
+      wireExtension: { tx: 0, rx: 0 },
+      blocksUploaded: 0,
+      blocksDownloaded: 0,
+      bytesUploaded: 0,
+      bytesDownloaded: 0
     }
 
     this.receiverQueue = new ReceiverQueue()
@@ -754,6 +758,11 @@ class Peer {
     }
 
     if (proof.block !== null) {
+      this.stats.blocksUploaded++
+      this.stats.bytesUploaded += proof.block.value.byteLength
+      this.replicator.stats.blocksUploaded++
+      this.replicator.stats.bytesUploaded += proof.block.value.byteLength
+
       this.replicator.onupload(proof.block.index, proof.block.value, this)
     }
 
@@ -1436,7 +1445,11 @@ module.exports = class Replicator {
       wireWant: { tx: 0, rx: 0 },
       wireBitfield: { tx: 0, rx: 0 },
       wireRange: { tx: 0, rx: 0 },
-      wireExtension: { tx: 0, rx: 0 }
+      wireExtension: { tx: 0, rx: 0 },
+      blocksUploaded: 0,
+      blocksDownloaded: 0,
+      bytesUploaded: 0,
+      bytesDownloaded: 0
     }
 
     this._attached = new Set()
@@ -2004,6 +2017,10 @@ module.exports = class Replicator {
 
   _ondata (peer, req, data) {
     if (data.block !== null) {
+      this.stats.blocksDownloaded++
+      this.stats.bytesDownloaded += data.block.value.byteLength
+      peer.stats.blocksDownloaded++
+      peer.stats.bytesDownloaded += data.block.value.byteLength
       this._resolveBlockRequest(this._blocks, data.block.index, data.block.value, req)
     }
 

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -28,7 +28,7 @@ test('basic replication', async function (t) {
 test('basic replication stats', async function (t) {
   const a = await create()
 
-  await a.append(['a', 'b', 'c', 'd', 'e'])
+  await a.append(['aa', 'bb', 'cc', 'dd', 'ee'])
 
   const b = await create(a.key)
 
@@ -51,9 +51,13 @@ test('basic replication stats', async function (t) {
   t.is(aStats.wireExtension.tx, 0, 'wireExtension init 0')
   t.is(aStats.wireCancel.rx, 0, 'wireCancel init 0')
   t.is(aStats.wireCancel.tx, 0, 'wireCancel init 0')
+  t.is(aStats.blocksUploaded, 0, 'blocksUploaded init 0')
+  t.is(aStats.blocksDownloaded, 0, 'blocksDownloaded init 0')
+  t.is(aStats.bytesUploaded, 0, 'bytesUploaded init 0')
+  t.is(aStats.bytesDownloaded, 0, 'bytesDownloaded init 0')
 
   const initStatsLength = [...Object.keys(aStats)].length
-  t.is(initStatsLength, 8, 'Expected amount of stats')
+  t.is(initStatsLength, 12, 'Expected amount of stats')
 
   replicate(a, b, t)
 
@@ -79,6 +83,11 @@ test('basic replication stats', async function (t) {
 
   t.ok(bStats.wireRange.rx > 0, 'wireRange incremented')
   t.is(aStats.wireRange.tx, bStats.wireRange.rx, 'wireRange received == transmitted')
+
+  t.ok(aStats.blocksUploaded > 0, 'blocksUploaded incremented')
+  t.is(aStats.bytesUploaded, aStats.blocksUploaded * 2, '2 bytes per block') // Because the entries all consist of 2 bytes (like aa)
+  t.is(bStats.blocksDownloaded, aStats.blocksUploaded, 'blocks uploaded == downloaded')
+  t.is(bStats.bytesDownloaded, aStats.bytesUploaded, 'bytes uploaded == downloaded')
 
   // extension messages
   const aExt = a.registerExtension('test-extension', {


### PR DESCRIPTION
If you prefer, we can also use
```
blocks: { uploaded: 0, downloaded: 0 }
```
Instead of
```
blocksUploaded: 0,
blocksDownloaded: 0
```

But I found that looked a bit strange (particularly for `bytes`)