### PR TITLE
Clean up onconflict logic (partially)

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -649,8 +649,8 @@ module.exports = class Core {
     this.updateContiguousLength({ start, length, drop: true })
   }
 
-  async _onconflict (proof, from) {
-    await this.replicator.onconflict(from)
+  async _onconflict (proof) {
+    await this.replicator.onconflict()
 
     for (let i = this.monitors.length - 1; i >= 0; i--) {
       const s = this.monitors[i]

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -1578,7 +1578,7 @@ module.exports = class Replicator {
   }
 
   // Called externally when a conflict has been detected and verified
-  async onconflict (from) {
+  async onconflict () {
     const all = []
     for (const peer of this.peers) {
       all.push(peer._onconflict())

--- a/test/conflicts.js
+++ b/test/conflicts.js
@@ -19,16 +19,12 @@ test('one forks', async function (t) {
   const streams = replicate(a, b, t)
 
   // Note: 'conflict' can be emitted more than once (no guarantees on that)
-  let cSeen = false
-  c.on('conflict', function (length) {
-    if (!cSeen) t.is(length, 5, 'conflict at 5 seen by c')
-    cSeen = true
+  c.once('conflict', function (length) {
+    t.is(length, 5, 'conflict at 5 seen by c')
   })
 
-  let bSeen = false
-  b.on('conflict', function (length) {
-    if (!bSeen) t.is(length, 5, 'conflict at 5 seen by b')
-    bSeen = true
+  b.once('conflict', function (length) {
+    t.is(length, 5, 'conflict at 5 seen by b')
   })
 
   await b.get(2)


### PR DESCRIPTION
I couldn't find an easy way to figure out the flakiness, so I stopped at fixing an obvious logic bug in the test, and getting rid of an unused argument in the onconflict functions