### PR TITLE
Support checkouts for named sessions only

### DIFF
--- a/index.js
+++ b/index.js
@@ -208,6 +208,9 @@ class Hypercore extends EventEmitter {
       // in practice, open an issue and we'll try to make a solution for it.
       throw SESSION_CLOSED('Cannot make sessions on a closing core')
     }
+    if (opts.checkout && !opts.name) {
+      throw new Error('Checkouts are only supported on named sessions')
+    }
 
     const wait = opts.wait === false ? false : this.wait
     const writable = opts.writable === undefined ? !this._readonly : opts.writable === true

--- a/index.js
+++ b/index.js
@@ -208,8 +208,8 @@ class Hypercore extends EventEmitter {
       // in practice, open an issue and we'll try to make a solution for it.
       throw SESSION_CLOSED('Cannot make sessions on a closing core')
     }
-    if (opts.checkout && !opts.name) {
-      throw new Error('Checkouts are only supported on named sessions')
+    if (opts.checkout !== undefined && opts.name === undefined && opts.atom === undefined) {
+      throw new Error('Checkouts are only supported on atoms or named sessions')
     }
 
     const wait = opts.wait === false ? false : this.wait

--- a/index.js
+++ b/index.js
@@ -208,7 +208,7 @@ class Hypercore extends EventEmitter {
       // in practice, open an issue and we'll try to make a solution for it.
       throw SESSION_CLOSED('Cannot make sessions on a closing core')
     }
-    if (opts.checkout !== undefined && opts.name === undefined && opts.atom === undefined) {
+    if (opts.checkout !== undefined && !opts.name && !opts.atom) {
       throw new Error('Checkouts are only supported on atoms or named sessions')
     }
 

--- a/test/atomic.js
+++ b/test/atomic.js
@@ -46,7 +46,7 @@ test('atomic - checkout session', async function (t) {
 
   const atom = core.state.storage.createAtom()
 
-  const atomic = core.session({ atom, checkout: 1, name: 'atomic-session' })
+  const atomic = core.session({ atom, checkout: 1 })
   await atomic.ready()
 
   await atomic.append('edits!')

--- a/test/atomic.js
+++ b/test/atomic.js
@@ -46,7 +46,7 @@ test('atomic - checkout session', async function (t) {
 
   const atom = core.state.storage.createAtom()
 
-  const atomic = core.session({ atom, checkout: 1 })
+  const atomic = core.session({ atom, checkout: 1, name: 'atomic-session' })
   await atomic.ready()
 
   await atomic.append('edits!')

--- a/test/sessions.js
+++ b/test/sessions.js
@@ -102,3 +102,18 @@ test.skip('session on a from instance does not inject itself to other sessions',
   await c.close()
   await d.close()
 })
+
+test('sessions - cannot set checkout if name not set', async function (t) {
+  const storage = await createStorage(t)
+  const core = new Hypercore(storage)
+  await core.append('Block0')
+
+  t.exception(
+    () => core.session({ checkout: 0 }),
+    /Checkouts are only supported on atoms or named sessions/
+  )
+
+  t.execution(() => core.session({ checkout: 0, name: 'named' }), 'sanity check on happy path')
+
+  await core.close()
+})

--- a/test/sessions.js
+++ b/test/sessions.js
@@ -65,7 +65,7 @@ test('sessions - truncate a checkout session', async function (t) {
 
   const atom = storage.createAtom()
 
-  const session = core.session({ checkout: 7, atom })
+  const session = core.session({ checkout: 7, atom, name: 'a-session' })
   await session.ready()
 
   t.is(session.length, 7)

--- a/test/sessions.js
+++ b/test/sessions.js
@@ -65,7 +65,7 @@ test('sessions - truncate a checkout session', async function (t) {
 
   const atom = storage.createAtom()
 
-  const session = core.session({ checkout: 7, atom, name: 'a-session' })
+  const session = core.session({ checkout: 7, atom })
   await session.ready()
 
   t.is(session.length, 7)


### PR DESCRIPTION
Currently it's unsafe to use the checkout option without the name option. This PR makes it explicit that this is not supported.