### PR TITLE
Fix flaky 'remote has larger tree' test

### DIFF
--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - rocksdb
+      - no-cancel-on-close
     tags: # To trigger the canary
       - '*'
   pull_request:

--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -4,7 +4,6 @@ on:
     branches:
       - main
       - rocksdb
-      - no-cancel-on-close
     tags: # To trigger the canary
       - '*'
   pull_request:

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -13,6 +13,7 @@ exports.create = async function (t, ...args) {
   await core.ready()
 
   t.teardown(() => core.close(), { order: 1 })
+  // t.teardown(() => core.close().catch(safetyCatch), { order: 1 })
 
   return core
 }

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -12,8 +12,7 @@ exports.create = async function (t, ...args) {
   const core = new Hypercore(db, ...args)
   await core.ready()
 
-  t.teardown(() => core.close(), { order: 1 })
-  // t.teardown(() => core.close().catch(safetyCatch), { order: 1 })
+  t.teardown(() => core.close().catch(safetyCatch), { order: 1 })
 
   return core
 }

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -1446,7 +1446,9 @@ for (let i = 0; i < 10000; i++) {
     }
 
     replicate(b, c, t)
-    c.get(4) // unresolvable but should not crash anything
+    const p = c.get(5)
+    p.catch(noop) // Throws a REQUEST_CANCELLED error during teardown
+
     await eventFlush()
     t.ok(!!(await c.get(2)), 'got block #2')
     t.ok(!!(await c.get(3)), 'got block #3')

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -1419,37 +1419,39 @@ test('manifests gossip eagerly sync', async function (t) {
   })
 })
 
-test('remote has larger tree', async function (t) {
-  const a = await create(t)
-  const b = await create(t, a.key)
-  const c = await create(t, a.key)
+for (let i = 0; i < 1000; i++) {
+  test.solo('remote has larger tree', async function (t) {
+    const a = await create(t)
+    const b = await create(t, a.key)
+    const c = await create(t, a.key)
 
-  await a.append(['a', 'b', 'c', 'd', 'e'])
+    await a.append(['a', 'b', 'c', 'd', 'e'])
 
-  {
-    const [s1, s2] = replicate(a, b, t, { teardown: false })
-    await b.get(2)
-    await b.get(3)
-    await b.get(4)
-    s1.destroy()
-    s2.destroy()
-  }
+    {
+      const [s1, s2] = replicate(a, b, t, { teardown: false })
+      await b.get(2)
+      await b.get(3)
+      await b.get(4)
+      s1.destroy()
+      s2.destroy()
+    }
 
-  await a.append('f')
+    await a.append('f')
 
-  {
-    const [s1, s2] = replicate(a, c, t, { teardown: false })
+    {
+      const [s1, s2] = replicate(a, c, t, { teardown: false })
+      await eventFlush()
+      s1.destroy()
+      s2.destroy()
+    }
+
+    replicate(b, c, t)
+    c.get(4) // unresolvable but should not crash anything
     await eventFlush()
-    s1.destroy()
-    s2.destroy()
-  }
-
-  replicate(b, c, t)
-  c.get(4) // unresolvable but should not crash anything
-  await eventFlush()
-  t.ok(!!(await c.get(2)), 'got block #2')
-  t.ok(!!(await c.get(3)), 'got block #3')
-})
+    t.ok(!!(await c.get(2)), 'got block #2')
+    t.ok(!!(await c.get(3)), 'got block #3')
+  })
+}
 
 test('range download, single block missing', async function (t) {
   const a = await create(t)

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -1419,41 +1419,39 @@ test('manifests gossip eagerly sync', async function (t) {
   })
 })
 
-for (let i = 0; i < 10000; i++) {
-  test.solo('remote has larger tree', async function (t) {
-    const a = await create(t)
-    const b = await create(t, a.key)
-    const c = await create(t, a.key)
+test('remote has larger tree', async function (t) {
+  const a = await create(t)
+  const b = await create(t, a.key)
+  const c = await create(t, a.key)
 
-    await a.append(['a', 'b', 'c', 'd', 'e'])
+  await a.append(['a', 'b', 'c', 'd', 'e'])
 
-    {
-      const [s1, s2] = replicate(a, b, t, { teardown: false })
-      await b.get(2)
-      await b.get(3)
-      await b.get(4)
-      s1.destroy()
-      s2.destroy()
-    }
+  {
+    const [s1, s2] = replicate(a, b, t, { teardown: false })
+    await b.get(2)
+    await b.get(3)
+    await b.get(4)
+    s1.destroy()
+    s2.destroy()
+  }
 
-    await a.append('f')
+  await a.append('f')
 
-    {
-      const [s1, s2] = replicate(a, c, t, { teardown: false })
-      await eventFlush()
-      s1.destroy()
-      s2.destroy()
-    }
-
-    replicate(b, c, t)
-    const p = c.get(5)
-    p.catch(noop) // Throws a REQUEST_CANCELLED error during teardown
-
+  {
+    const [s1, s2] = replicate(a, c, t, { teardown: false })
     await eventFlush()
-    t.ok(!!(await c.get(2)), 'got block #2')
-    t.ok(!!(await c.get(3)), 'got block #3')
-  })
-}
+    s1.destroy()
+    s2.destroy()
+  }
+
+  replicate(b, c, t)
+  const p = c.get(5)
+  p.catch(noop) // Throws a REQUEST_CANCELLED error during teardown
+
+  await eventFlush()
+  t.ok(!!(await c.get(2)), 'got block #2')
+  t.ok(!!(await c.get(3)), 'got block #3')
+})
 
 test('range download, single block missing', async function (t) {
   const a = await create(t)

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -1419,7 +1419,7 @@ test('manifests gossip eagerly sync', async function (t) {
   })
 })
 
-for (let i = 0; i < 1000; i++) {
+for (let i = 0; i < 10000; i++) {
   test.solo('remote has larger tree', async function (t) {
     const a = await create(t)
     const b = await create(t, a.key)


### PR DESCRIPTION
The test was flaky in a subtle way:

- The intent of `c.get(4) // unresolvable but should not crash anything` was to get a block that's not resolvable
- But that block was in fact resolvable (fixed to `c.get(5)` in this PR)
- This caused a low-likelihood race condition, which is the actual bug: `core.get(i)` should always have a catch handler, because any pending requests are cancelled with an error when the hypercore closes. The error triggered when the request had not yet resolved by the time test teardown started.

Fixed by requesting the correct block, and adding a catch handler