### PR TITLE
Bugfix: set bitfields to correct value

### DIFF
--- a/lib/session-state.js
+++ b/lib/session-state.js
@@ -1096,7 +1096,7 @@ async function storeBitfieldRange (storage, tx, from, to, value) {
     const pageIndex = i + firstPage
     if (!pages[i]) pages[i] = b4a.alloc(Bitfield.BYTES_PER_PAGE)
 
-    index = fillBitfieldPage(pages[i], index, to, pageIndex, true)
+    index = fillBitfieldPage(pages[i], index, to, pageIndex, value)
     tx.putBitfieldPage(pageIndex, pages[i])
   }
 }

--- a/test/basic.js
+++ b/test/basic.js
@@ -612,6 +612,7 @@ test('truncate has correct storage state in memory and persisted', async functio
     const core = new Hypercore(storage)
     await core.ready()
     t.alike(getBitfields(core, 0, 5), [true, true, false, false, false])
+    await core.close()
   }
 })
 
@@ -631,6 +632,7 @@ test('clear has correct storage state in memory and persisted', async function (
     const core = new Hypercore(storage)
     await core.ready()
     t.alike(getBitfields(core, 0, 5), [true, true, false, true, true])
+    await core.close()
   }
 })
 


### PR DESCRIPTION
The `value` argument was previously ignored, so the calls from `clear` and `truncate` (with `value=false`) were not working correctly.

<strike>Note: needs tests still</strike> Added tests which failed on previous behaviour (it didn't show on the in-memory view, but did show after reloading the storage)