### PR TITLE
Remove used `sign` option in manifest test

### DIFF
--- a/test/manifest.js
+++ b/test/manifest.js
@@ -867,9 +867,9 @@ test('multisig - normal operating mode', async function (t) {
   const signer1 = signer(a, b)
   const signer2 = signer(b, d)
 
-  const core = await create(t, { manifest, sign: signer1.sign })
+  const core = await create(t, { manifest })
 
-  const core2 = await create(t, { manifest, sign: signer2.sign })
+  const core2 = await create(t, { manifest })
   await core.ready()
 
   let ai = 0


### PR DESCRIPTION
I cannot find where these options are used. They were introduced in the test in this commit (https://github.com/holepunchto/hypercore/commit/a308fe79f622f9d5339bb4fcbb27409ed8d7715a) which has a line item "support passing a sign function" but has another line item "remove sign option and just pass keyPair or signature" so I assume these are just left over.