### PR TITLE
Check truncate invar after getting lock

### DIFF
--- a/lib/session-state.js
+++ b/lib/session-state.js
@@ -359,19 +359,15 @@ module.exports = class SessionState {
   }
 
   async truncate (length, fork, { signature, keyPair } = {}) {
-    if (this.prologue && length < this.prologue.length) {
-      throw INVALID_OPERATION('Truncation breaks prologue')
-    }
-
     if (!keyPair && this.isDefault()) keyPair = this.core.header.keyPair
 
     await this.mutex.lock()
 
-    if (this.prologue && length < this.prologue.length) {
-      throw INVALID_OPERATION('Truncation breaks prologue')
-    }
-
     try {
+      if (this.prologue && length < this.prologue.length) {
+        throw INVALID_OPERATION('Truncation breaks prologue')
+      }
+
       const batch = this.createTreeBatch()
       await MerkleTree.truncate(this, length, batch, fork)
 

--- a/lib/session-state.js
+++ b/lib/session-state.js
@@ -367,6 +367,11 @@ module.exports = class SessionState {
 
     await this.mutex.lock()
 
+    if (this.prologue && length < this.prologue.length) {
+      throw INVALID_OPERATION('Truncation breaks prologue')
+    }
+
+
     try {
       const batch = this.createTreeBatch()
       await MerkleTree.truncate(this, length, batch, fork)

--- a/lib/session-state.js
+++ b/lib/session-state.js
@@ -371,7 +371,6 @@ module.exports = class SessionState {
       throw INVALID_OPERATION('Truncation breaks prologue')
     }
 
-
     try {
       const batch = this.createTreeBatch()
       await MerkleTree.truncate(this, length, batch, fork)


### PR DESCRIPTION
Current code assumes that, if the invar holds before the lock, it always holds after the lock is acquired. With this change, we check it again before proceeding.

Note that a similar race condition can occur on the keyPair, so maybe `if (!keyPair && this.isDefault()) keyPair = this.core.header.keyPair` needs to move till after the lock (if the keyPair can ever change, which I believe is possible for autobase cores)