### PR TITLE
Safe lock usage for reorg

### DIFF
--- a/lib/session-state.js
+++ b/lib/session-state.js
@@ -406,10 +406,10 @@ module.exports = class SessionState {
   async reorg (batch) {
     await this.mutex.lock()
 
-    const storage = this.createWriteBatch()
-
     try {
       if (!batch.commitable()) return false
+
+      const storage = this.createWriteBatch()
 
       const { dependency, tree } = await this._truncate(storage, batch)
 


### PR DESCRIPTION
In other functions, `createWriteBatch` lives inside the try too. This avoids deadlock should `createWriteBatch` ever throw