### PR TITLE
Update readme v11

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Make a new Hypercore instance.
 const core = new Hypercore('./directory') // store data in ./directory
 ```
 
-Alternatively you can pass a [Hypercore Storage](https://github.com/holepunchto/hypercore-storage) or use a [Corestore](https://github.com/holepunchto/corestore) if you want to make many Hypercores efficiently.
+Alternatively you can pass a [Hypercore Storage](https://github.com/holepunchto/hypercore-storage) or use a [Corestore](https://github.com/holepunchto/corestore) if you want to make many Hypercores efficiently. Note that `random-access-storage` is no longer supported.
 
 `key` can be set to a Hypercore key which is a hash of Hypercore's internal auth manifest, describing how to validate the Hypercore. If you do not set this, it will be loaded from storage. If nothing is previously stored, a new auth manifest will be generated giving you local write access to it.
 

--- a/README.md
+++ b/README.md
@@ -327,8 +327,7 @@ console.log((await core.get(core.length - 1)).toString()) // prints 'atom block 
 
 #### `const { byteLength, length } = core.commit(session, opts = {})`
 
-Attempt to apply blocks from the session to the `core`. `core` must be a default
-core, aka a non-named session.
+Attempt to apply blocks from the session to the `core`. `core` must be a default core, aka a non-named session.
 
 Returns `null` if committing failed.
 

--- a/README.md
+++ b/README.md
@@ -303,12 +303,7 @@ Options are inherited from the parent instance, unless they are re-set.
 }
 ```
 
-Atoms allow making atomic changes across multiple hypercores. Atoms can be created using
-a `core`'s `storage` (eg. `const atom = core.state.storage.createAtom()`). Changes made with
-an atom based session is not persisted until the atom is flushed via
-`await atom.flush()`, but can be read at any time. When atoms flush, all
-changes made outside of the atom will be clobbered as the core blocks will now
-match the atom's blocks. For example:
+Atoms allow making atomic changes across multiple hypercores. Atoms can be created using a `core`'s `storage` (eg. `const atom = core.state.storage.createAtom()`). Changes made with an atom based session is not persisted until the atom is flushed via `await atom.flush()`, but can be read at any time. When atoms flush, all changes made outside of the atom will be clobbered as the core blocks will now match the atom's blocks. For example:
 
 ```js
 const core = new Hypercore('./atom-example')

--- a/README.md
+++ b/README.md
@@ -438,8 +438,7 @@ Populated after `ready` has been emitted. Will be `0` before the event.
 
 #### `core.signedLength`
 
-How many blocks of data are available on this core that have been signed by a
-quorum. This is equal to `core.length` for Hypercores's with a single signer.
+How many blocks of data are available on this core that have been signed by a quorum. This is equal to `core.length` for Hypercores's with a single signer.
 
 Populated after `ready` has been emitted. Will be `0` before the event.
 

--- a/README.md
+++ b/README.md
@@ -303,19 +303,12 @@ Options are inherited from the parent instance, unless they are re-set.
 }
 ```
 
-Atoms allow making atomic changes across hypercores. Atoms can be created using
+Atoms allow making atomic changes across multiple hypercores. Atoms can be created using
 a `core`'s `storage` (eg. `const atom = core.state.storage.createAtom()`). Changes made with
 an atom based session is not persisted until the atom is flushed via
 `await atom.flush()`, but can be read at any time. When atoms flush, all
 changes made outside of the atom will be clobbered as the core blocks will now
 match the atom's blocks. For example:
-
-#### `const { byteLength, length } = core.commit(session, opts = {})`
-
-Attempt to apply blocks from the session to the `core`. `core` must be a default
-core, aka a non-named session.
-
-Returns `null` if committing failed.
 
 ```js
 const core = new Hypercore('./atom-example')
@@ -333,6 +326,13 @@ await atom.flush()
 
 console.log((await core.get(core.length - 1)).toString()) // prints 'atom block 2' not 'block 2'
 ```
+
+#### `const { byteLength, length } = core.commit(session, opts = {})`
+
+Attempt to apply blocks from the session to the `core`. `core` must be a default
+core, aka a non-named session.
+
+Returns `null` if committing failed.
 
 #### `const snapshot = core.snapshot([options])`
 

--- a/README.md
+++ b/README.md
@@ -397,6 +397,13 @@ How many blocks of data are available on this core.
 
 Populated after `ready` has been emitted. Will be `0` before the event.
 
+#### `core.signedLength`
+
+How many blocks of data are available on this core that have been signed by a
+quorum. This is equal to `core.length` for Hypercores's with a single signer.
+
+Populated after `ready` has been emitted. Will be `0` before the event.
+
 #### `core.contiguousLength`
 
 How many blocks are contiguously available starting from the first block of this core?

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Alternatively you can pass a [Hypercore Storage](https://github.com/holepunchto/
   valueEncoding: 'json' | 'utf-8' | 'binary', // defaults to binary
   encodeBatch: batch => { ... }, // optionally apply an encoding to complete batches
   keyPair: kp, // optionally pass the public key and secret key as a key pair
-  encryptionKey: k, // optionally pass an encryption key to enable block encryption
+  encryption: { key: buffer }, // the block encryption key
   onwait: () => {}, // hook that is called if gets are waiting for download
   timeout: 0, // wait at max some milliseconds (0 means no timeout)
   writable: true, // disable appends and truncates

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Alternatively you can pass a [Hypercore Storage](https://github.com/holepunchto/
   onwait: () => {}, // hook that is called if gets are waiting for download
   timeout: 0, // wait at max some milliseconds (0 means no timeout)
   writable: true, // disable appends and truncates
-  inflightRange: null // Advanced option. Set to [minInflight, maxInflight] to change the min and max inflight blocks per peer when downloading.
+  inflightRange: null, // Advanced option. Set to [minInflight, maxInflight] to change the min and max inflight blocks per peer when downloading.
   ongc: (session) => { ... }, // A callback called when the session is garbage collected
   notDownloadingLinger: 20000, // How many milliseconds to wait after downloading finishes keeping the connection open. Defaults to a random number between 20-40s
   allowFork: true, // Enables updating core when it forks

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ Alternatively you can pass a [Hypercore Storage](https://github.com/holepunchto/
 {
   createIfMissing: true, // create a new Hypercore key pair if none was present in storage
   overwrite: false, // overwrite any old Hypercore that might already exist
-  sparse: true, // enable sparse mode, counting unavailable blocks towards core.length and core.byteLength
   valueEncoding: 'json' | 'utf-8' | 'binary', // defaults to binary
   encodeBatch: batch => { ... }, // optionally apply an encoding to complete batches
   keyPair: kp, // optionally pass the public key and secret key as a key pair
@@ -394,7 +393,7 @@ Buffer containing the optional block encryption key of this core. Will be `null`
 
 #### `core.length`
 
-How many blocks of data are available on this core? If `sparse: false`, this will equal `core.contiguousLength`.
+How many blocks of data are available on this core.
 
 Populated after `ready` has been emitted. Will be `0` before the event.
 

--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ Alternatively you can pass a [Hypercore Storage](https://github.com/holepunchto/
   timeout: 0, // wait at max some milliseconds (0 means no timeout)
   writable: true, // disable appends and truncates
   inflightRange: null // Advanced option. Set to [minInflight, maxInflight] to change the min and max inflight blocks per peer when downloading.
+  ongc: (session) => { ... }, // A callback called when the session is garbage collected
+  notDownloadingLinger: 20000, // How many milliseconds to wait after downloading finishes keeping the connection open. Defaults to a random number between 20-40s
+  allowFork: true, // Enables updating core when it forks
 }
 ```
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -4,7 +4,7 @@ Notes for downstream developers who are upgrading their modules to new, breaking
 
 ## 11.0.0
 
-- `sparse` is no longer an option. All hypercores are sparse.
+- `sparse` is no longer an option when creating a `Hypercore` instance. All hypercores are sparse.
 - `encryptionKey` will deprecated in favor of the `encryption` option when creating a `Hypercore` instance.
 - Storage is now auto migrated to [`hypercore-storage`](https://github.com/holepunchto/hypercore-storage) if a path `storage` argument was used.  
   If you are getting a `TypeError: db.columnFamily is not a function` error, you

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -6,6 +6,10 @@ Notes for downstream developers who are upgrading their modules to new, breaking
 
 - `sparse` is no longer an option. All hypercores are sparse.
 - `encryptionKey` will deprecated in favor of the `encryption` option when creating a `Hypercore` instance.
+- Storage is now auto migrated to [`hypercore-storage`](https://github.com/holepunchto/hypercore-storage) if a path `storage` argument was used.  
+  If you are getting a `TypeError: db.columnFamily is not a function` error, you
+  are likely trying to use a legacy `random-access-storage` instance such as
+  `random-access-memory` or `random-access-file`.
 - `core.indexedLength` is now `core.signedLength`
 
 ## 10.0.0

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,7 @@ Notes for downstream developers who are upgrading their modules to new, breaking
 ## 11.0.0
 
 - `sparse` is no longer an option. All hypercores are sparse.
+- `core.indexedLength` is now `core.signedLength`
 
 ## 10.0.0
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -5,6 +5,7 @@ Notes for downstream developers who are upgrading their modules to new, breaking
 ## 11.0.0
 
 - `sparse` is no longer an option. All hypercores are sparse.
+- `encryptionKey` will deprecated in favor of the `encryption` option when creating a `Hypercore` instance.
 - `core.indexedLength` is now `core.signedLength`
 
 ## 10.0.0

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -2,6 +2,10 @@
 
 Notes for downstream developers who are upgrading their modules to new, breaking versions of Hypercore.
 
+## 11.0.0
+
+- `sparse` is no longer an option. All hypercores are sparse.
+
 ## 10.0.0
 
 - All number encodings are now LE

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -901,7 +901,7 @@ test('one inflight request to a peer per block', async function (t) {
 
 test.skip('non-sparse replication', async function (t) {
   const a = await create(t)
-  const b = await create(t, a.key, { sparse: false })
+  const b = await create(t, a.key)
 
   await a.append(['a', 'b', 'c', 'd', 'e'])
 
@@ -1033,7 +1033,7 @@ test('download range resolves immediately if no peers', async function (t) {
 
 test('download available blocks on non-sparse update', async function (t) {
   const a = await create(t)
-  const b = await create(t, a.key, { sparse: false })
+  const b = await create(t, a.key)
 
   replicate(a, b, t)
 


### PR DESCRIPTION
- Updated `UPGRADE.md`
  - Noted that all hypercores are sparse now
  - Potential error if not migrating storage to the new `hypercore-storage`
  - That `encryption` option replaces `encryptionKey`
- Clarified that `random-access-storage` is no longer supported
- Options in `Hypercore` constructor
- Using atoms
- Mention named sessions with a caveat that they may change
- Other `core.session()` options
  - `weak`
  - `checkout`

The following options I found but don't know if they need to be documented:

`Hypercore` constructor:

```
  ongc: (session) => { ... }, // A callback called when the session is garbage collected
  notDownloadingLinger: 20000, // How many milliseconds to wait after downloading finishes keeping the connection open. Defaults to a random number between 20-40s
  allowFork: true, // Enables updating core when it forks
```

`core.session()`:

```
  exclusive: false, // Create a session with exclusive access to the core. Creating an exclusive session on a core with other exclusive sessions, will wait for the session with access to close before the next exclusive session is `ready`
```