### PR TITLE
Do not include bool when emitting a close event

### DIFF
--- a/index.js
+++ b/index.js
@@ -290,7 +290,7 @@ class Hypercore extends EventEmitter {
       if (this.state !== null) this.state.removeSession(this)
 
       this.closed = true
-      this.emit('close', this.core.hasSession() === false)
+      this.emit('close')
       throw err
     }
 
@@ -476,14 +476,14 @@ class Hypercore extends EventEmitter {
     if (this.core.hasSession()) {
       // emit "fake" close as this is a session
       this.closed = true
-      this.emit('close', false)
+      this.emit('close')
       return
     }
 
     if (this.core.autoClose) await this.core.close()
 
     this.closed = true
-    this.emit('close', true)
+    this.emit('close')
   }
 
   async commit (session, opts) {


### PR DESCRIPTION
Technically a breaking change, but this boolean argument was not documented.

Removing because it is no longer correctly indicating whether this was the last session (due to the concept of weak sessions, like in the passive-core-watcher)