### PR TITLE
add `nanoassert`; bump `sodium-native` to `5.0.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,11 +55,12 @@
     "hypercore-id-encoding": "^1.2.0",
     "hypercore-storage": "^1.0.0",
     "is-options": "^1.0.1",
+    "nanoassert": "^2.0.0",
     "protomux": "^3.5.0",
     "quickbit-universal": "^2.2.0",
     "random-array-iterator": "^1.0.0",
     "safety-catch": "^1.0.1",
-    "sodium-universal": "^4.0.0",
+    "sodium-universal": "^5.0.1",
     "streamx": "^2.12.4",
     "unslab": "^1.3.0",
     "z32": "^1.0.0"


### PR DESCRIPTION
Depends on:

- https://github.com/holepunchto/hypercore-encryption/pull/3 
- https://github.com/holepunchto/hypercore-crypto/pull/19
