### PR TITLE
Win end when live is added in readstream

### DIFF
--- a/lib/streams.js
+++ b/lib/streams.js
@@ -8,7 +8,7 @@ class ReadStream extends Readable {
     this.start = opts.start || 0
     this.end = typeof opts.end === 'number' ? opts.end : -1
     this.snapshot = !opts.live && opts.snapshot !== false
-    this.live = this.end === -1 ?  !!opts.live : false
+    this.live = this.end === -1 ? !!opts.live : false
   }
 
   _open (cb) {

--- a/lib/streams.js
+++ b/lib/streams.js
@@ -8,7 +8,7 @@ class ReadStream extends Readable {
     this.start = opts.start || 0
     this.end = typeof opts.end === 'number' ? opts.end : -1
     this.snapshot = !opts.live && opts.snapshot !== false
-    this.live = !!opts.live
+    this.live = this.end === -1 ?  !!opts.live : false
   }
 
   _open (cb) {

--- a/test/streams.js
+++ b/test/streams.js
@@ -82,9 +82,6 @@ test('read stream with end and live (live should be ignored)', async function (t
   }
 
   t.alike(collected, expected)
-
-  t.is(collected.includes('delta'), false)
-  t.is(collected.includes('epsilon'), false)
 })
 
 test('basic write+read stream', async function (t) {

--- a/test/streams.js
+++ b/test/streams.js
@@ -61,12 +61,18 @@ test('read stream with end and live (live should be ignored)', async function (t
   const initial = [
     'alpha',
     'beta',
-    'gamma'
+    'gamma',
+    'delta',
+    'epsilon'
   ]
 
   await core.append(initial)
 
-  const expected = [...initial]
+  const expected = [
+    'alpha',
+    'beta',
+    'gamma'
+  ]
 
   const stream = core.createReadStream({ end: 3, live: true })
   const collected = []
@@ -76,8 +82,6 @@ test('read stream with end and live (live should be ignored)', async function (t
   }
 
   t.alike(collected, expected)
-
-  await core.append(['delta', 'epsilon'])
 
   t.is(collected.includes('delta'), false)
   t.is(collected.includes('epsilon'), false)

--- a/test/streams.js
+++ b/test/streams.js
@@ -55,6 +55,34 @@ test('read stream with start / end', async function (t) {
   }
 })
 
+test('read stream with end and live (live should be ignored)', async function (t) {
+  const core = await create(t)
+
+  const initial = [
+    'alpha',
+    'beta',
+    'gamma'
+  ]
+
+  await core.append(initial)
+
+  const expected = [...initial]
+
+  const stream = core.createReadStream({ end: 3, live: true })
+  const collected = []
+
+  for await (const data of stream) {
+    collected.push(b4a.toString(data))
+  }
+
+  t.alike(collected, expected)
+
+  await core.append(['delta', 'epsilon'])
+
+  t.is(collected.includes('delta'), false)
+  t.is(collected.includes('epsilon'), false)
+})
+
 test('basic write+read stream', async function (t) {
   const core = await create(t)
 


### PR DESCRIPTION
Currently in `Hypercore.createReadStream({live: true, start: startIndex, end: startIndex }) `  "live" and "end" are two conflicting options, having "end" blocks won't work if live is true.

This PR makes sure that end wins in live vs end.