### PR TITLE
Use brittle when running 'npm test'

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Hypercore is a secure, distributed append-only log",
   "main": "index.js",
   "scripts": {
-    "test": "standard && node test/all.js",
+    "test": "standard && brittle test/all.js",
     "test:bare": "bare test/all.js",
     "test:generate": "brittle -r test/all.js test/*.js"
   },


### PR DESCRIPTION
This way we can call `BRITTLE=--timeout 120000 npm test`, once https://github.com/holepunchto/brittle/pull/79 is released 