### PR TITLE
Add hotswap test with many peers + cleanup test lifecycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "hyperswarm": "^4.3.6",
     "rache": "^1.0.0",
     "range-parser": "^1.2.1",
+    "resolve-reject-promise": "^1.1.0",
     "speedometer": "^1.1.0",
     "standard": "^17.0.0",
     "test-tmp": "^1.0.2",

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -1943,6 +1943,53 @@ test('download event includes "elapsed" time in metadata', async function (t) {
   await b.download({ start: 0, end: a.length }).done()
 })
 
+test('hotswap works for a download with many slow peers', async function (t) {
+  const nrBlocks = 500
+  const nrSeeders = 20
+  const nrQuickCores = 1
+  // Very big latency, will cause test timeout if hotswap does not trigger and divert to the quick peer
+  const latency = [10000, 10000]
+
+  const a = await create(t)
+  for (let i = 0; i < nrBlocks; i++) await a.append('data')
+
+  const seeders = [a]
+  {
+    const proms = []
+    for (let i = 0; i < nrSeeders; i++) {
+      proms.push(createAndDownload(t, a))
+    }
+    seeders.push(...await Promise.all(proms))
+  }
+
+  const downloader = await create(t, a.key)
+
+  for (let i = 0; i < nrQuickCores; i++) {
+    const core = seeders.pop()
+    const [n1, n2] = makeStreamPair(t, { latency: [0, 0] })
+    core.replicate(n1)
+    downloader.replicate(n2)
+  }
+  for (const core of seeders) {
+    const [n1, n2] = makeStreamPair(t, { latency })
+    core.replicate(n1)
+    downloader.replicate(n2)
+  }
+
+  const start = Date.now()
+  const download = downloader.download({ start: 0, end: a.length })
+  await download.done()
+
+  t.pass(`Hotswap triggered (download took ${Date.now() - start}ms)`)
+})
+
+async function createAndDownload (t, core) {
+  const b = await create(t, core.key)
+  replicate(core, b, t, { teardown: false })
+  await b.download({ start: 0, end: core.length }).done()
+  return b
+}
+
 async function waitForRequestBlock (core) {
   while (true) {
     const reqBlock = core.core.replicator._inflight._requests.find(req => req && req.block)


### PR DESCRIPTION
Without the fixes to test/helpers/networking, teardown hangs forever. After fixing that (with the `order`s), I added an additional fix to cancel the delay timeouts when tearing down.