### PR TITLE
Include discovery key in error messages

### DIFF
--- a/index.js
+++ b/index.js
@@ -716,7 +716,7 @@ class Hypercore extends EventEmitter {
     const offset = await s.update()
     if (offset) return offset
 
-    if (this.closing !== null) throw SESSION_CLOSED(undefined, this.discoveryKey)
+    if (this.closing !== null) throw SESSION_CLOSED('cannot seek on a closed session', this.discoveryKey)
 
     if (!this._shouldWait(opts, this.wait)) return null
 

--- a/index.js
+++ b/index.js
@@ -1097,7 +1097,7 @@ function maybeUnslab (block) {
 }
 
 function checkSnapshot (snapshot, index) {
-  if (index >= snapshot.state.snapshotCompatLength) throw SNAPSHOT_NOT_AVAILABLE(undefined, this.discoveryKey)
+  if (index >= snapshot.state.snapshotCompatLength) throw SNAPSHOT_NOT_AVAILABLE(undefined, snapshot.discoveryKey)
 }
 
 function readBlock (rx, index) {

--- a/lib/core.js
+++ b/lib/core.js
@@ -146,17 +146,17 @@ module.exports = class Core {
     }
 
     if (!header && (opts.discoveryKey && !(opts.key || opts.manifest))) {
-      throw STORAGE_EMPTY('No Hypercore is stored here')
+      throw STORAGE_EMPTY('No Hypercore is stored here', this.discoveryKey)
     }
 
     if (!header || overwrite) {
       if (!createIfMissing) {
-        throw STORAGE_EMPTY('No Hypercore is stored here')
+        throw STORAGE_EMPTY('No Hypercore is stored here', this.discoveryKey)
       }
 
       if (compat) {
         if (opts.key && opts.keyPair && !b4a.equals(opts.key, opts.keyPair.publicKey)) {
-          throw BAD_ARGUMENT('Key must match publicKey when in compat mode')
+          throw BAD_ARGUMENT('Key must match publicKey when in compat mode', this.discoveryKey)
         }
       }
 
@@ -216,14 +216,14 @@ module.exports = class Core {
     if (opts.manifest) {
       // if we provide a manifest and no key, verify that the stored key is the same
       if (!opts.key && !Verifier.isValidManifest(header.key, Verifier.createManifest(opts.manifest))) {
-        throw STORAGE_CONFLICT('Manifest does not hash to provided key')
+        throw STORAGE_CONFLICT('Manifest does not hash to provided key', this.discoveryKey)
       }
 
       if (!header.manifest) header.manifest = opts.manifest
     }
 
     if (opts.key && !b4a.equals(header.key, opts.key)) {
-      throw STORAGE_CONFLICT('Another Hypercore is stored here')
+      throw STORAGE_CONFLICT('Another Hypercore is stored here', this.discoveryKey)
     }
 
     // if we signalled compat, but already now this core isn't disable it
@@ -298,7 +298,7 @@ module.exports = class Core {
 
     try {
       if (manifest && this.header.manifest === null) {
-        if (!Verifier.isValidManifest(this.header.key, manifest)) throw INVALID_CHECKSUM('Manifest hash does not match')
+        if (!Verifier.isValidManifest(this.header.key, manifest)) throw INVALID_CHECKSUM('Manifest hash does not match', this.discoveryKey)
 
         const tx = this.state.createWriteBatch()
         this._setManifest(tx, Verifier.createManifest(manifest), null)
@@ -385,13 +385,13 @@ module.exports = class Core {
       if (!manifest) manifest = Verifier.defaultSignerManifest(this.header.key)
 
       if (!manifest || !(Verifier.isValidManifest(this.header.key, manifest) || Verifier.isCompat(this.header.key, manifest))) {
-        throw INVALID_SIGNATURE('Proof contains an invalid manifest') // TODO: proper error type
+        throw INVALID_SIGNATURE('Proof contains an invalid manifest', this.discoveryKey) // TODO: proper error type
       }
     }
 
     const verifier = this.verifier || new Verifier(this.header.key, Verifier.createManifest(manifest), { legacy: this._legacy })
     if (!verifier.verify(batch, batch.signature)) {
-      throw INVALID_SIGNATURE('Proof contains an invalid signature')
+      throw INVALID_SIGNATURE('Proof contains an invalid signature', this.discoveryKey)
     }
 
     return manifest
@@ -451,7 +451,7 @@ module.exports = class Core {
 
         // if we got a manifest AND its strictly a non compat one, lets store it
         if (manifest && this.header.manifest === null) {
-          if (!Verifier.isValidManifest(this.header.key, manifest)) throw INVALID_CHECKSUM('Manifest hash does not match')
+          if (!Verifier.isValidManifest(this.header.key, manifest)) throw INVALID_CHECKSUM('Manifest hash does not match', this.discoveryKey)
           this._setManifest(tx, manifest, null)
         }
 

--- a/lib/session-state.js
+++ b/lib/session-state.js
@@ -611,7 +611,6 @@ module.exports = class SessionState {
 
   _updateBitfield (bitfield, flushed) {
     if (!bitfield) return
-    console.log(this.core.discoveryKey)
 
     const p = this._pendingBitfield
     const b = bitfield

--- a/lib/session-state.js
+++ b/lib/session-state.js
@@ -373,10 +373,10 @@ module.exports = class SessionState {
 
     try {
       if (this.prologue && length < this.prologue.length) {
-        throw INVALID_OPERATION('Truncation breaks prologue')
+        throw INVALID_OPERATION('Truncation breaks prologue', this.core.discoveryKey)
       }
       if (length > this.length) {
-        throw INVALID_OPERATION('Not a truncation, ' + length + ' must be less or equal to ' + this.length)
+        throw INVALID_OPERATION('Not a truncation, ' + length + ' must be less or equal to ' + this.length, this.core.discoveryKey)
       }
 
       const batch = this.createTreeBatch()
@@ -531,7 +531,7 @@ module.exports = class SessionState {
 
       // only multisig can have prologue so signature is always present
       if (this.prologue && batch.length < this.prologue.length) {
-        throw INVALID_OPERATION('Append is not consistent with prologue')
+        throw INVALID_OPERATION('Append is not consistent with prologue', this.core.discoveryKey)
       }
 
       if (!signature && keyPair) signature = this.core.verifier.sign(batch, keyPair)
@@ -611,6 +611,7 @@ module.exports = class SessionState {
 
   _updateBitfield (bitfield, flushed) {
     if (!bitfield) return
+    console.log(this.core.discoveryKey)
 
     const p = this._pendingBitfield
     const b = bitfield
@@ -618,7 +619,7 @@ module.exports = class SessionState {
     if (b.drop) {
       // truncation must be from end
       if (p && (b.start + b.length !== p.start + p.appends)) {
-        throw INVALID_OPERATION('Atomic truncations must be contiguous')
+        throw INVALID_OPERATION('Atomic truncations must be contiguous', this.core.discoveryKey)
       }
 
       // actual truncation
@@ -642,7 +643,7 @@ module.exports = class SessionState {
     }
 
     if (b.start !== p.start + p.appends) {
-      throw INVALID_OPERATION('Atomic operations must be contiguous')
+      throw INVALID_OPERATION('Atomic operations must be contiguous', this.core.discoveryKey)
     }
 
     p.appends += b.length
@@ -679,7 +680,7 @@ module.exports = class SessionState {
       const truncating = sharedLength < origLength
 
       for (const node of roots) {
-        if (node === null) throw INVALID_OPERATION('Invalid catchup length, tree nodes not available')
+        if (node === null) throw INVALID_OPERATION('Invalid catchup length, tree nodes not available', this.core.discoveryKey)
       }
 
       const fork = truncating ? this.fork + 1 : this.fork
@@ -755,7 +756,7 @@ module.exports = class SessionState {
       batch.length = length
 
       if (!this.core.verifier.verify(batch, signature)) {
-        throw INVALID_SIGNATURE('Signature is not valid over committed tree')
+        throw INVALID_SIGNATURE('Signature is not valid over committed tree', this.core.discoveryKey)
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "fast-fifo": "^1.3.0",
     "flat-tree": "^1.9.0",
     "hypercore-crypto": "^3.2.1",
-    "hypercore-errors": "holepunchto/hypercore-errors#opt-disckey",
+    "hypercore-errors": "^1.5.0",
     "hypercore-id-encoding": "^1.2.0",
     "hypercore-storage": "^1.0.0",
     "is-options": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "fast-fifo": "^1.3.0",
     "flat-tree": "^1.9.0",
     "hypercore-crypto": "^3.2.1",
-    "hypercore-errors": "^1.2.0",
+    "hypercore-errors": "holepunchto/hypercore-errors#opt-disckey",
     "hypercore-id-encoding": "^1.2.0",
     "hypercore-storage": "^1.0.0",
     "is-options": "^1.0.1",

--- a/test/sessions.js
+++ b/test/sessions.js
@@ -3,6 +3,7 @@ const test = require('brittle')
 const crypto = require('hypercore-crypto')
 const c = require('compact-encoding')
 const b4a = require('b4a')
+const IdEnc = require('hypercore-id-encoding')
 const { create, createStorage } = require('./helpers')
 
 const Hypercore = require('../')
@@ -115,6 +116,22 @@ test('sessions - cannot set checkout if name not set', async function (t) {
   )
 
   t.execution(() => core.session({ checkout: 0, name: 'named' }), 'sanity check on happy path')
+
+  await core.close()
+})
+
+test('sessions - error includes discovery key', async function (t) {
+  const storage = await createStorage(t)
+  const core = new Hypercore(storage)
+  await core.append('Block0')
+
+  const discKey = IdEnc.normalize(core.discoveryKey)
+  try {
+    await core.session({ checkout: 0 })
+    t.fail('Should throw')
+  } catch (e) {
+    t.is(e.message.includes(discKey), true)
+  }
 
   await core.close()
 })

--- a/test/snapshots.js
+++ b/test/snapshots.js
@@ -243,11 +243,15 @@ test('error when using inconsistent snapshot', async function (t) {
   await core.append('block #1.0')
   await core.append('block #2.0')
 
+  const snapshot = core.snapshot()
   try {
-    await core.snapshot().get(1000)
+    await snapshot.get(1000)
     t.fail('should throw')
   } catch (e) {
     t.is(e.code, 'SNAPSHOT_NOT_AVAILABLE')
     t.is(e.message.includes(IdEnc.normalize(core.discoveryKey)), true, 'error message includes the discovery key')
   }
+
+  await snapshot.close()
+  await core.close()
 })


### PR DESCRIPTION
I only included it when we have trivial access to the discovery key (index.js, core.js, session-state.js). This covers most errors we throw.

It's not yet included in errors thrown from:
- lib/merkle-tree
- lib/messages
- lib/replicator
- lib/verifier

We can add it to those later, if relevant (for most it's possible to get the discovery key in a more roundabout way).