### PR TITLE
Avoid uncaught promises by awaiting multiple in objs

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -815,9 +815,10 @@ async function getCoreInfo (storage) {
 
   r.tryFlush()
 
+  const [authInfo, headInfo, hintsInfo] = await Promise.all([auth, head, hints])
   return {
-    ...await auth,
-    head: await head,
-    hints: await hints
+    ...authInfo,
+    head: headInfo,
+    hints: hintsInfo
   }
 }

--- a/lib/info.js
+++ b/lib/info.js
@@ -26,17 +26,11 @@ module.exports = class Info {
   static async storage (session) {
     const { oplog, tree, blocks, bitfield } = session.core
     try {
-      const [oplogBytes, treeBytes, blocksBytes, bitfieldBytes] = await Promise.all([
-        Info.bytesUsed(oplog.storage),
-        Info.bytesUsed(tree.storage),
-        Info.bytesUsed(blocks.storage),
-        Info.bytesUsed(bitfield.storage)
-      ])
       return {
-        oplog: oplogBytes,
-        tree: treeBytes,
-        blocks: blocksBytes,
-        bitfield: bitfieldBytes
+        oplog: await Info.bytesUsed(oplog.storage),
+        tree: await Info.bytesUsed(tree.storage),
+        blocks: await Info.bytesUsed(blocks.storage),
+        bitfield: await Info.bytesUsed(bitfield.storage)
       }
     } catch {
       return null

--- a/lib/info.js
+++ b/lib/info.js
@@ -26,11 +26,17 @@ module.exports = class Info {
   static async storage (session) {
     const { oplog, tree, blocks, bitfield } = session.core
     try {
+      const [oplogBytes, treeBytes, blocksBytes, bitfieldBytes] = await Promise.all([
+        Info.bytesUsed(oplog.storage),
+        Info.bytesUsed(tree.storage),
+        Info.bytesUsed(blocks.storage),
+        Info.bytesUsed(bitfield.storage)
+      ])
       return {
-        oplog: await Info.bytesUsed(oplog.storage),
-        tree: await Info.bytesUsed(tree.storage),
-        blocks: await Info.bytesUsed(blocks.storage),
-        bitfield: await Info.bytesUsed(bitfield.storage)
+        oplog: oplogBytes,
+        tree: treeBytes,
+        blocks: blocksBytes,
+        bitfield: bitfieldBytes
       }
     } catch {
       return null


### PR DESCRIPTION
The following illustrates how this can occur:

```js
async function test () {
  const prom1 = new Promise((resolve) => setTimeout(resolve, 100))
  const prom2 = Promise.reject(Error('whoops'))

  return {
    a: await prom1,
    b: await prom2
  }
}

test().catch(() => console.log('catch'))
```

The `whoops` will reject before `prom1` is awaited causing it to be uncaught.