### PR TITLE
Limit bitfield stream to pages based on length in `Bitfield.open()`

### DIFF
--- a/lib/bitfield.js
+++ b/lib/bitfield.js
@@ -492,7 +492,7 @@ module.exports = class Bitfield {
 
     const pages = Math.ceil(length / BITS_PER_PAGE)
     const buffer = b4a.alloc(pages * BYTES_PER_PAGE)
-    const stream = storage.createBitfieldStream()
+    const stream = storage.createBitfieldStream({ lt: pages })
 
     for await (const { index, page } of stream) {
       buffer.set(page, index * BYTES_PER_PAGE)

--- a/test/bitfield.js
+++ b/test/bitfield.js
@@ -68,10 +68,22 @@ test('bitfield - reload', async function (t) {
   }
 
   {
-    const b = await Bitfield.open(await createStorage(t, dir), 1424242425)
+    const storage = await createStorage(t, dir)
+    const b = await Bitfield.open(storage, 1424242425)
     t.ok(b.get(142))
     t.ok(b.get(40000))
     t.ok(b.get(1424242424))
+
+    // fully close db
+    await storage.db.close({ force: true })
+  }
+
+  {
+    const storage = await createStorage(t, dir)
+    const b = await Bitfield.open(storage, 40001)
+    t.ok(b.get(142))
+    t.ok(b.get(40000))
+    t.absent(b.get(1424242424))
   }
 })
 


### PR DESCRIPTION
The bitfield stream returned all pages even though it only expects the pages until the floor of `length` / `BITS_PER_PAGE`.

Discovered with the following minimal repo:
```js
const tmpDir = await t.tmp()
{
  const storage = new HypercoreStorage(tmpDir)
  const core = new Hypercore(storage)

  const BITS_PER_PAGE = 32768
  const atLeastTwoPages = BITS_PER_PAGE + 1

  await core.append(Array(atLeastTwoPages).fill('1'))
  await core.truncate(1)
  await core.append('A' + 2)
  await core.close()
}

{
  const storage = new HypercoreStorage(tmpDir)
  const core = new Hypercore(storage)
  await core.ready()
  t.is(core.length, 2)
  await core.close()
}
```