### PR TITLE
Fix `BitInterlude` tests and edgecases

### DIFF
--- a/lib/bit-interlude.js
+++ b/lib/bit-interlude.js
@@ -75,14 +75,18 @@ module.exports = class BitInterlude {
       // we overran but our start is contained in this interval, move start back
       if (start >= r.start && start <= r.end) {
         if (r.value !== value) {
-          // There's a next range
+          r.end = start // Crop current comparison
+
+          // If there's a next range
           if (this.ranges.length - 1 > i) {
             const next = this.ranges[i + 1]
-            // We overlap so update next range
+            // If the same, go next
+            if (next.value === value) continue
+            // Else we overlap so update next range
             if (next.start < end) next.start = end
           }
+
           this.ranges.splice(++i, 0, { start, end, value })
-          r.end = start
           return
         }
 

--- a/lib/bit-interlude.js
+++ b/lib/bit-interlude.js
@@ -75,6 +75,12 @@ module.exports = class BitInterlude {
       // we overran but our start is contained in this interval, move start back
       if (start >= r.start && start <= r.end) {
         if (r.value !== value) {
+          // There's a next range
+          if (this.ranges.length - 1 > i) {
+            const next = this.ranges[i + 1]
+            // We overlap so update next range
+            if (next.start < end) next.start = end
+          }
           this.ranges.splice(++i, 0, { start, end, value })
           r.end = start
           return

--- a/test/bit-interlude.js
+++ b/test/bit-interlude.js
@@ -70,3 +70,27 @@ test('bit-interlude - set & drop', t => {
   t.is(bits.contiguousLength(12), 2)
   t.is(bits.contiguousLength(16), 2)
 })
+
+test('bit-interlude - setRange bridges undefine region updates higher range', t => {
+  const bits = new BitInterlude()
+
+  // Indexes:  [0123456789]
+  // Existing: [11111  111]
+  // Applied:  [     000  ]
+  // Expected: [1111100011]
+
+  // Setup of two ranges w/ gap inbetween
+  bits.setRange(0, 5, true)
+  bits.setRange(7, 10, true)
+
+  // Applying "bridge" range
+  bits.setRange(5, 8, false)
+
+  t.is(bits.get(7), false)
+
+  // Add ranges to the end to make the range after the bridge range the midpoint.
+  bits.setRange(10, 11, false)
+  bits.setRange(11, 12, true)
+
+  t.is(bits.get(7), false, 'bit not updated should stay the same')
+})

--- a/test/bit-interlude.js
+++ b/test/bit-interlude.js
@@ -1,10 +1,8 @@
 const test = require('brittle')
 const BitInterlude = require('../lib/bit-interlude')
 
-const bitfield = (val = false) => ({ get () { return val } })
-
 test('bit-interlude - basic', t => {
-  const bits = new BitInterlude(bitfield())
+  const bits = new BitInterlude()
 
   bits.setRange(0, 5, true)
   bits.setRange(10, 15, true)
@@ -22,7 +20,8 @@ test('bit-interlude - basic', t => {
 })
 
 test('bit-interlude - drop', t => {
-  const bits = new BitInterlude(bitfield(true))
+  const bits = new BitInterlude()
+  bits.setRange(0, 20, true)
 
   bits.setRange(15, 20, false)
 
@@ -35,7 +34,8 @@ test('bit-interlude - drop', t => {
 })
 
 test('bit-interlude - drop multiple', t => {
-  const bits = new BitInterlude(bitfield(true))
+  const bits = new BitInterlude()
+  bits.setRange(0, 20, true)
 
   bits.setRange(0, 10, false)
   bits.setRange(15, 20, false)
@@ -51,7 +51,7 @@ test('bit-interlude - drop multiple', t => {
 })
 
 test('bit-interlude - set & drop', t => {
-  const bits = new BitInterlude(bitfield())
+  const bits = new BitInterlude()
 
   bits.setRange(0, 10, true)
   bits.setRange(7, 12, false)

--- a/test/bit-interlude.js
+++ b/test/bit-interlude.js
@@ -94,3 +94,25 @@ test('bit-interlude - setRange bridges undefine region updates higher range', t 
 
   t.is(bits.get(7), false, 'bit not updated should stay the same')
 })
+
+test('bit-interlude - setRange overlap but next range is same', t => {
+  const bits = new BitInterlude()
+
+  // Indexes:  [0123456789]
+  // Existing: [11111  000]
+  // Applied:  [     000  ]
+  // Expected: [1111100000]
+
+  // Setup of two ranges w/ gap inbetween
+  bits.setRange(0, 5, true)
+  bits.setRange(7, 10, false)
+
+  // Applying overlapping range
+  bits.setRange(5, 8, false)
+
+  t.is(bits.get(7), false)
+  t.alike(bits.ranges, [
+    { start: 0, end: 5, value: true },
+    { start: 5, end: 10, value: false }
+  ])
+})


### PR DESCRIPTION
While setting ranges, it was possible to overlap with a current range (which updates the current range) but the next range was ignored. Resulting in the next range being inaccurate. These edgecases are illustrated with the new tests (added in c273e7f2982da26233c9f72c5aa6b8e768dd47c0 and d857886c057352bf72ccfe92a1cc7c89d489172b) that fail until the fixes.