### PR TITLE
Only set keepAlive when it is not yet set

### DIFF
--- a/README.md
+++ b/README.md
@@ -762,7 +762,6 @@ Create an encrypted noise stream with a protomux instance attached used for Hype
 
 ```
 {
-  keepAlive: true, // Whether to keep the stream alive
   ondiscoverykey: () => {}, // A handler for when a discovery key is set over the stream for corestore management
 }
 ```

--- a/index.js
+++ b/index.js
@@ -146,7 +146,7 @@ class Hypercore extends EventEmitter {
     if (!noiseStream.userData) {
       const protocol = Protomux.from(noiseStream)
 
-      if (opts.keepAlive !== false) {
+      if (opts.keepAlive !== false && noiseStream.keepAlive === 0) {
         noiseStream.setKeepAlive(5000)
       }
       noiseStream.userData = protocol


### PR DESCRIPTION
It should already be set by hyperdht for all normal use cases. I opted for this approach instead of never setting it to keep it backwards compatible.

Note: I removed it from the docs, because I don't think users should ever need this option.