### PR TITLE
Get range index via `indexOf()` instead of tracking it as prop

### DIFF
--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -187,7 +187,7 @@ class RangeRequest extends Attachable {
     this.ifAvailable = ifAvailable
     this.blocks = blocks
     this.ranges = ranges
-    this.rangeIndex = ranges.push(this) - 1
+    ranges.push(this)
 
     if (this.end === -1) {
       this.replicator._alwaysLatestBlock++
@@ -199,13 +199,12 @@ class RangeRequest extends Attachable {
   }
 
   _unref() {
-    if (this.rangeIndex >= this.ranges.length) return
-    if (this.ranges[this.rangeIndex] !== this) return
+    const rangeIndex = this.ranges.indexOf(this)
+    if (rangeIndex === -1) return
 
     const h = this.ranges.pop()
     if (h !== this) {
-      this.ranges[this.rangeIndex] = h
-      h.rangeIndex = this.rangeIndex
+      this.ranges[rangeIndex] = h
     }
 
     if (this.end === -1) {


### PR DESCRIPTION
More expensive than tracking the index on the request, but the range array is manipulated by others so the index is hard to track accurately.