### PR TITLE
Fix contig signal review

### DIFF
--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -1890,7 +1890,7 @@ module.exports = class Replicator {
     }
 
     for (const peer of this.peers) {
-      peer.fullyDownloadedSignaled = 0
+      peer.fullyDownloadedSignaled = Math.min(newLength, peer.fullyDownloadedSignaled)
       peer._unclearLocalRange(newLength, truncated)
     }
   }


### PR DESCRIPTION
Review of #755.

- Removed a now unused method for checking if fully downloaded.
- Update `.fullyDownloadedSignal` to the minimum length when truncating instead of resetting to `0`.
  This should be safe to do given truncation starts at a new 'shared' length so would then include previously signaled contiguous lenths.