### PR TITLE
`lint` as Separate Task

### DIFF
--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -14,8 +14,8 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1 https://github.com/actions/checkout/releases/tag/v4.1.1
+      - uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2 https://github.com/actions/setup-node/releases/tag/v3.8.2
       - run: npm install
       - run: npm run lint
   build:


### PR DESCRIPTION
This is to protect against supply-chain attacks. See https://github.com/holepunchto/hypercore/pull/454 for original fixing of the hashes for the `build` task.

Alternatively to pinning the hashes for the external actions, we could change to using the holepunch actions.