### PR TITLE
Track waits on session

### DIFF
--- a/index.js
+++ b/index.js
@@ -855,9 +855,9 @@ class Hypercore extends EventEmitter {
 
     if (!this._shouldWait(opts, this.wait)) return null
 
+    this.waits++
     if (opts && opts.onwait) opts.onwait(index, this)
     if (this.onwait) this.onwait(index, this)
-    this.waits++
 
     const activeRequests = (opts && opts.activeRequests) || this.activeRequests
 

--- a/test/basic.js
+++ b/test/basic.js
@@ -290,14 +290,26 @@ test('downloading local range', async function (t) {
 })
 
 test('read ahead', async function (t) {
-  t.plan(3)
+  t.plan(7)
 
-  const core = new Hypercore(await createStorage(t), { valueEncoding: 'utf-8' })
+  const core = new Hypercore(await createStorage(t), {
+    valueEncoding: 'utf-8',
+    onwait: () => {
+      t.is(core.waits, 1, 'waits correct in onwait on core')
+      t.pass('onwait on core called')
+    }
+  })
 
   await core.append('a')
 
   t.is(core.waits, 0, 'no waits yet')
-  const blk = core.get(1, { wait: true }) // readahead
+  const blk = core.get(1, {
+    wait: true,
+    onwait: () => {
+      t.is(core.waits, 1, 'waits correct in onwait on get')
+      t.pass('onwait on get called')
+    }
+  }) // readahead
 
   await eventFlush()
 


### PR DESCRIPTION
Adds the `.waits` property to track when blocks are requested from remotes. The property is updated before `onwait` handlers.

There were no tests covering the `onwait` handlers so they were added to the `read ahead` test.