### PR TITLE
Ready sessions prior to parent append in tests

### DIFF
--- a/test/batch.js
+++ b/test/batch.js
@@ -51,6 +51,7 @@ test('append to core during batch', async function (t) {
   await core.append(['a', 'b', 'c'])
 
   const b = core.session({ name: 'batch' })
+  await b.ready()
   await core.append('d')
   await b.append('e')
   t.is(await core.commit(b), null)
@@ -718,6 +719,7 @@ test('compact all batches', async function (t) {
   const a = new Hypercore(await createStorage(t))
 
   const a1 = a.session({ name: 's1' })
+  await a1.ready()
 
   for (let i = 0; i < 50; i++) {
     await a.append('data ' + i)
@@ -725,6 +727,7 @@ test('compact all batches', async function (t) {
   }
 
   const a2 = a.session({ name: 's2' })
+  await a2.ready()
 
   for (let i = 50; i < 100; i++) {
     await a.append('data ' + i)
@@ -732,6 +735,7 @@ test('compact all batches', async function (t) {
   }
 
   const a3 = a.session({ name: 's3' })
+  await a3.ready()
   for (let i = 100; i < 150; i++) {
     await a.append('data ' + i)
     await a3.append('s3 data ' + i)

--- a/test/manifest.js
+++ b/test/manifest.js
@@ -369,7 +369,7 @@ test('multisig - batch failed', async function (t) {
 
   t.is(len, 1)
 
-  const batch = await core.session({ name: 'batch' })
+  const batch = core.session({ name: 'batch' })
   batch.keyPair = null
 
   await batch.append(b4a.from('0'))

--- a/test/sessions.js
+++ b/test/sessions.js
@@ -127,7 +127,7 @@ test('sessions - error includes discovery key', async function (t) {
 
   const discKey = IdEnc.normalize(core.discoveryKey)
   try {
-    await core.session({ checkout: 0 })
+    core.session({ checkout: 0 })
     t.fail('Should throw')
   } catch (e) {
     t.is(e.message.includes(discKey), true)


### PR DESCRIPTION
The tests could flake due to the `.append()` on the parent core resolving before the named session fully opened. This included the block when the tests were assuming it wasn't included.

Also remove useless `await`ing of sessions noticed while finding instances of sessions potentially not being ready in tests.