### PR TITLE
Use `onwait` callback to ensure `waits` test doesnt flake

### DIFF
--- a/test/basic.js
+++ b/test/basic.js
@@ -338,7 +338,9 @@ test('defaults for wait', async function (t) {
 
   t.is(s.waits, 0, 'no waits yet')
   let _resolveWait
-  const waited = new Promise((resolve) => { _resolveWait = resolve })
+  const waited = new Promise((resolve) => {
+    _resolveWait = resolve
+  })
   const b = s.get(1, { wait: true, onwait: () => _resolveWait() })
 
   b.catch(function (err) {


### PR DESCRIPTION
The IO async calls could cause the second get request to complete (since it doesnt wait) before checking that `waits` didn't increment.

Fixes this flake:
https://github.com/holepunchto/hypercore/actions/runs/21955099190/job/63416652325#step:7:253