### PR TITLE
Fix DefaultEncryption key reload on runtime compat flips + add regression coverage

### DIFF
--- a/lib/default-encryption.js
+++ b/lib/default-encryption.js
@@ -98,7 +98,8 @@ module.exports = class DefaultEncryption {
     const block = b4a.equals(this.key, this.blockKey)
     const keys = DefaultEncryption.deriveKeys(this.key, core.key, { block, compat: core.compat })
 
-    this.blockKey = keys.blockKey
-    this.blindingKey = keys.blindingKey
+    this.compat = core.compat
+    this.blockKey = keys.block
+    this.blindingKey = keys.blinding
   }
 }

--- a/test/encryption.js
+++ b/test/encryption.js
@@ -2,7 +2,8 @@ const test = require('brittle')
 const b4a = require('b4a')
 const crypto = require('hypercore-crypto')
 const Hypercore = require('..')
-const { create, createStorage, replicate } = require('./helpers')
+const Verifier = require('../lib/verifier')
+const { create, createStorage, createStored, replicate } = require('./helpers')
 
 const fixturesRaw = require('./fixtures/encryption/v11.0.48.cjs')
 
@@ -371,6 +372,46 @@ test('encryption backwards compatibility', async function (t) {
   for (let i = 0; i < block.length; i++) {
     t.alike(await block.get(i, { raw: true }), fixtures[3][i])
   }
+})
+
+test('encryption reloads keys when manifest flips compat mode at runtime', async function (t) {
+  const keyPair = crypto.keyPair()
+  const manifest = Verifier.createManifest({
+    quorum: 1,
+    signers: [
+      {
+        signature: 'ed25519',
+        publicKey: keyPair.publicKey
+      }
+    ]
+  })
+
+  const key = Verifier.manifestHash(manifest)
+  const open = await createStored(t)
+
+  // Create storage with a key-only core so manifest is absent on disk.
+  const bootstrap = await open(key, { compat: false })
+  await bootstrap.ready()
+  await bootstrap.close()
+
+  const core = await open(key, { compat: true })
+  await core.ready()
+
+  await core.setEncryptionKey(encryptionKey)
+  t.is(core.core.compat, true, 'starts in compat mode before manifest is known')
+
+  // This sets the manifest on the shared core during session open.
+  const s = core.session({ manifest })
+  await s.ready()
+
+  t.is(core.core.compat, false, 'compat mode flips after manifest is set')
+
+  await core.encryption.decrypt(0, b4a.alloc(core.padding), core)
+  t.ok(core.encryption.blockKey, 'reload keeps a valid block key')
+  t.ok(core.encryption.blindingKey, 'reload keeps a valid blinding key')
+
+  await s.close()
+  await core.close()
 })
 
 function getBlock(core, index) {

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -2887,7 +2887,7 @@ test('local writable caught up by remote', async function (t) {
   t.is(b.length, a.length)
 })
 
-test.solo('local recovering from remote', async function (t) {
+test('local recovering from remote', async function (t) {
   const a = await create(t)
 
   await a.append(['a', 'b', 'c', 'd', 'e'])


### PR DESCRIPTION
 This PR fixes a runtime encryption bug in DefaultEncryption that could surface when core.compat changes after a session is already open (for example, when a manifest is learned later and persisted). It also adds a regression test that reproduces this transition and validates the fix.

### Summary
Hypercore supports paths where a core starts without a local manifest and later receives one (for example, via session open with manifest, or replication manifest sync). When that happens, internal core.compat can transition at runtime. Encryption providers account for this by reloading derived keys when compat mode changes. Before this PR, that reload path was broken and could produce undefined keys, leading to runtime failures in decrypt/encrypt paths.

  - Updated _reload in lib/default-encryption.js (/Users/shahidshaikh/Projects/hypercore/lib/default-encryption.js) to:
      - assign correct fields: keys.block, keys.blinding
      - update mode state: this.compat = core.compat

  - Extended test/encryption.js (/Users/shahidshaikh/Projects/hypercore/test/encryption.js) with:
      - encryption reloads keys when manifest flips compat mode at runtime
  - Test flow:
      1. Create a key-only core (manifest unknown locally)
      2. Reopen with compat: true
      3. Enable encryption
      4. Attach manifest via session (forcing compat transition)
      5. Trigger encryption path and assert keys remain valid

  - Replaced test.solo(...) with test(...) in test/replicate.js (/Users/shahidshaikh/Projects/hypercore/test/replicate.js) so the full suite can execute normally.

### Tests

  - npx brittle test/encryption.js
      - Result: 16/16 tests pass, including the new regression test.
  - npx brittle test/all.js
      - Result: Full suite now runs broadly (hundreds of tests).
      - Run in this environment stopped at a networking permission error (udx-native bind EPERM) during a replication networking test, indicating environment restriction
        rather than functional regression.