### PR TITLE
Fix `core.clear(..., { diff: true })`

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,15 @@ The core will also gossip to peers it is connected to, that is no longer has the
 
 ```js
 {
-  diff: false // Returned `cleared` bytes object is null unless you enable this
+  diff: false // Returned `cleared` object is null unless you enable this
+}
+```
+
+`cleared` object when `diff` is `true` will look like:
+
+```
+{
+  blocks: Number // The number of blocks cleared
 }
 ```
 

--- a/lib/session-state.js
+++ b/lib/session-state.js
@@ -548,8 +548,7 @@ class SessionState {
       }
 
       if (cleared) {
-        const blocksToClear = this.core.bitfield.countSet(start, end - start)
-        cleared.blocks = blocksToClear
+        cleared.blocks = this.core.bitfield.countSet(start, end - start)
       }
 
       if (end - start === 1) tx.deleteBlock(start)

--- a/lib/session-state.js
+++ b/lib/session-state.js
@@ -547,6 +547,11 @@ class SessionState {
         }
       }
 
+      if (cleared) {
+        const blocksToClear = this.core.bitfield.countSet(start, end - start)
+        cleared.blocks = blocksToClear
+      }
+
       if (end - start === 1) tx.deleteBlock(start)
       else tx.deleteBlockRange(start, end)
 

--- a/test/clear.js
+++ b/test/clear.js
@@ -95,13 +95,11 @@ test('clear blocks with diff option', async function (t) {
   const cleared = await core.clear(1337)
   t.is(cleared, null)
 
-  // todo: reenable bytes use api
+  const cleared2 = await core.clear(0, { diff: true })
+  t.ok(cleared2.blocks > 0)
 
-  // const cleared2 = await core.clear(0, { diff: true })
-  // t.ok(cleared2.blocks > 0)
-
-  // const cleared3 = await core.clear(0, { diff: true })
-  // t.is(cleared3.blocks, 0)
+  const cleared3 = await core.clear(0, { diff: true })
+  t.is(cleared3.blocks, 0)
 
   await core.close()
 })


### PR DESCRIPTION
Previously was left unimplemented after moving to rocks due to limited knowledge about bytes used for a core. But the `blocks` property can be known as it is a hypercore concept.

README.md & tests adjusted. Currently doesn't test named or atomic sessions.