### PR TITLE
Await all storage promises at once in `_overwrite()`

### DIFF
--- a/lib/session-state.js
+++ b/lib/session-state.js
@@ -881,9 +881,11 @@ class SessionState {
 
     rx.tryFlush()
 
-    const blocks = await Promise.all(blockPromises)
-    const nodes = await Promise.all(treePromises)
-    const roots = await Promise.all(rootPromises)
+    const [blocks, nodes, roots] = await Promise.all([
+      Promise.all(blockPromises),
+      Promise.all(treePromises),
+      Promise.all(rootPromises)
+    ])
 
     if (this.core.destroyed) throw new Error('Core destroyed')
 


### PR DESCRIPTION
If any of the earlier promises (eg `blockPromises`) throw, the other arrays of promises which haven't been awaited yet could also throw uncaught errors since execution will leave the `_overwrite()` scope and no caught handlers will have been added.