### PR TITLE
Batch remote bitfield index refreshes

### DIFF
--- a/lib/remote-bitfield.js
+++ b/lib/remote-bitfield.js
@@ -51,11 +51,15 @@ class RemoteBitfieldPage {
 
   insert(start, bitfield) {
     this.bitfield.set(bitfield, start / 32)
-    this.segment.refresh()
   }
 
   clear(start, bitfield) {
     quickbit.clear(this.bitfield, { field: bitfield, offset: start })
+
+    let i = Math.floor(start / 128)
+    const n = i + Math.ceil((bitfield.byteLength * 8) / 128)
+
+    while (i <= n) this.tree.update(this.offset * 8 + i++ * 128)
   }
 }
 
@@ -283,6 +287,7 @@ module.exports = class RemoteBitfield {
 
     let j = start & (BITS_PER_PAGE - 1)
     let i = (start - j) / BITS_PER_PAGE
+    const refresh = new Set()
 
     while (length > 0) {
       let p = this._pages.get(i)
@@ -299,6 +304,7 @@ module.exports = class RemoteBitfield {
       const range = end - j
 
       p.insert(j, bitfield.subarray(0, range / 32))
+      refresh.add(p.segment)
 
       bitfield = bitfield.subarray(range / 32)
 
@@ -306,6 +312,8 @@ module.exports = class RemoteBitfield {
       i++
       length -= range
     }
+
+    for (const segment of refresh) segment.refresh()
 
     return true
   }

--- a/test/remote-bitfield.js
+++ b/test/remote-bitfield.js
@@ -1,5 +1,6 @@
 const test = require('brittle')
 const b4a = require('b4a')
+const quickbit = require('../lib/compat').quickbit
 const RemoteBitfield = require('../lib/remote-bitfield')
 const { create, replicate } = require('./helpers')
 
@@ -25,6 +26,47 @@ test('remote bitfield - set range to false', function (t) {
   b.setRange(0, 5000, false)
 
   t.is(b.findFirst(true, 0), -1)
+})
+
+test('remote bitfield - batch refreshes insert indexes once per segment', function (t) {
+  const from = quickbit.Index.from
+  let sparseIndexes = 0
+
+  quickbit.Index.from = function (fieldOrChunks, byteLength) {
+    if (Array.isArray(fieldOrChunks)) sparseIndexes++
+    return from.call(this, fieldOrChunks, byteLength)
+  }
+
+  t.teardown(function () {
+    quickbit.Index.from = from
+  })
+
+  const b = new RemoteBitfield()
+  const bitfield = new Uint32Array(RemoteBitfield.BITS_PER_SEGMENT / 32)
+  bitfield.fill(0xffffffff)
+
+  b.insert(0, bitfield)
+
+  t.is(sparseIndexes, 2) // one segment init, one refresh
+  t.is(b.findFirst(true, 0), 0)
+  t.is(b.findFirst(false, 0), RemoteBitfield.BITS_PER_SEGMENT)
+})
+
+test('remote bitfield - clear refreshes indexes for firstUnset', function (t) {
+  const b = new RemoteBitfield()
+  const bitfield = new Uint32Array(RemoteBitfield.BITS_PER_PAGE / 32)
+  bitfield.fill(0xffffffff)
+
+  b.insert(0, bitfield)
+
+  const half = new Uint32Array(RemoteBitfield.BITS_PER_PAGE / 32)
+  half.fill(0xffffffff, 0, half.length / 2)
+
+  b.clear(0, half)
+
+  t.is(b.get(0), false)
+  t.is(b.findFirst(false, 0), 0)
+  t.is(b.findFirst(true, 0), RemoteBitfield.BITS_PER_PAGE / 2)
 })
 
 test('set last bits in segment and findFirst', function (t) {


### PR DESCRIPTION
Receiving a multi-page remote bitfield currently refreshes the sparse quickbit index once per 4 KiB page. For a full 2 MiB segment, that rebuilds the same segment index 64 times.

This changes `RemoteBitfield.insert()` to copy all touched pages first and refresh each touched segment once. It also updates `clear()` to keep the sparse index correct for `firstUnset()` without rebuilding the whole segment.

Bench notes from a local microbench over 100 inserts:

```text
4096 bytes (1 pages): 0.039ms/insert, sparse index builds 101
16384 bytes (4 pages): 0.063ms/insert, sparse index builds 101
65536 bytes (16 pages): 0.144ms/insert, sparse index builds 101
262144 bytes (64 pages): 0.278ms/insert, sparse index builds 101
```

Before this change, the 262144-byte/full-segment case rebuilt the sparse index once per page and measured around 21ms/insert locally. After this change, it refreshes once per segment.

This addresses the `quickbit_napi_index_init_sparse` hotspot seen in a blind-peer CPU profile. The separate `onclose -> _removePeer -> updateAll` hotspot is intentionally left for a separate fix.

Tests:

```text
npx brittle test/remote-bitfield.js
npx prettier --check lib/remote-bitfield.js test/remote-bitfield.js
```
