### PR TITLE
Add close-path replication reschedule coverage

### DIFF
--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -2465,8 +2465,16 @@ module.exports = class Replicator {
 
     this._onpeerupdate(false, peer)
 
-    // If the peer had no requests to clear, there is nothing to reschedule.
-    if (needsUpdate && this.peers.length > 0) this.updateAll()
+    // A close can also wake pending work that was not assigned to the closing peer.
+    const hasPendingUpdate =
+      needsUpdate ||
+      this._queued.length > 0 ||
+      this._seeks.length > 0 ||
+      this._ranges.length > 0 ||
+      this._reorgs.length > 0 ||
+      this._maybeUpdate()
+
+    if (hasPendingUpdate && this.peers.length > 0) this.updateAll()
     else this._maybeResolveAvailable()
   }
 

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -754,7 +754,7 @@ class Peer {
 
     if (this.remoteOpened === false) {
       this.replicator._ifAvailable--
-      this.replicator.updateAll()
+      this.replicator._maybeResolveAvailable()
       return
     }
 
@@ -2449,16 +2449,25 @@ module.exports = class Replicator {
     this.peers.splice(this.peers.indexOf(peer), 1)
     peer.wants.destroy()
 
-    if (this._manifestPeer === peer) this._manifestPeer = null
+    let needsUpdate = false
+
+    if (this._manifestPeer === peer) {
+      this._manifestPeer = null
+      needsUpdate = true
+    }
 
     for (const req of this._inflight) {
       if (req.peer !== peer) continue
       this._inflight.remove(req.id, true)
       this._clearRequest(peer, req)
+      needsUpdate = true
     }
 
     this._onpeerupdate(false, peer)
-    this.updateAll()
+
+    // If the peer had no requests to clear, there is nothing to reschedule.
+    if (needsUpdate && this.peers.length > 0) this.updateAll()
+    else this._maybeResolveAvailable()
   }
 
   _queueBlock(b) {
@@ -2666,6 +2675,11 @@ module.exports = class Replicator {
         i--
       }
     }
+  }
+
+  _maybeResolveAvailable() {
+    this._checkUpgradeIfAvailable()
+    this._maybeResolveIfAvailableRanges()
   }
 
   _clearRequest(peer, req) {

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -754,7 +754,7 @@ class Peer {
 
     if (this.remoteOpened === false) {
       this.replicator._ifAvailable--
-      this.replicator._maybeResolveAvailable()
+      this.replicator.updateAll()
       return
     }
 
@@ -2449,33 +2449,16 @@ module.exports = class Replicator {
     this.peers.splice(this.peers.indexOf(peer), 1)
     peer.wants.destroy()
 
-    let needsUpdate = false
-
-    if (this._manifestPeer === peer) {
-      this._manifestPeer = null
-      needsUpdate = true
-    }
+    if (this._manifestPeer === peer) this._manifestPeer = null
 
     for (const req of this._inflight) {
       if (req.peer !== peer) continue
       this._inflight.remove(req.id, true)
       this._clearRequest(peer, req)
-      needsUpdate = true
     }
 
     this._onpeerupdate(false, peer)
-
-    // A close can also wake pending work that was not assigned to the closing peer.
-    const hasPendingUpdate =
-      needsUpdate ||
-      this._queued.length > 0 ||
-      this._seeks.length > 0 ||
-      this._ranges.length > 0 ||
-      this._reorgs.length > 0 ||
-      this._maybeUpdate()
-
-    if (hasPendingUpdate && this.peers.length > 0) this.updateAll()
-    else this._maybeResolveAvailable()
+    this.updateAll()
   }
 
   _queueBlock(b) {
@@ -2683,11 +2666,6 @@ module.exports = class Replicator {
         i--
       }
     }
-  }
-
-  _maybeResolveAvailable() {
-    this._checkUpgradeIfAvailable()
-    this._maybeResolveIfAvailableRanges()
   }
 
   _clearRequest(peer, req) {

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -899,13 +899,10 @@ test('closing idle peer schedules pending range on remaining peer', async functi
   const clone = await create(t, writer.key)
 
   const writerPeerWait = new Promise((resolve) => clone.once('peer-add', resolve))
-  const writerStreams = replicate(writer, clone, t, { teardown: false })
+  const writerStreams = replicate(writer, clone, t)
   const writerPeer = await writerPeerWait
 
-  const sparseStreams = replicate(sparse, clone, t, { teardown: false })
-
-  t.teardown(() => destroyStreams(writerStreams))
-  t.teardown(() => destroyStreams(sparseStreams))
+  const sparseStreams = replicate(sparse, clone, t)
 
   await clone.update({ wait: true })
   await eventFlush()

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -793,6 +793,52 @@ test('multiplexing multiple times over the same stream', async function (t) {
   s3.destroy()
 })
 
+test('closing peer with inflight block reschedules on remaining peer', async function (t) {
+  const writer = await create(t)
+  await writer.append(['block-0', 'block-1', 'block-2'])
+
+  const mirror = await create(t, writer.key)
+  replicate(writer, mirror, t)
+  await mirror.download({ start: 0, end: writer.length }).done()
+
+  const clone = await create(t, writer.key)
+
+  const [slowWriterStream, slowCloneStream] = makeStreamPair(t, { latency: [200, 200] })
+  writer.replicate(slowWriterStream, { keepAlive: true })
+  clone.replicate(slowCloneStream, { keepAlive: true })
+
+  const mirrorStreams = replicate(mirror, clone, t, { keepAlive: true, teardown: false })
+  t.teardown(() => destroyStreams(mirrorStreams))
+
+  await clone.update({ wait: true })
+  await eventFlush()
+
+  const slowPeer = await waitForPeerForStream(clone, slowWriterStream)
+  const mirrorPeer = await waitForPeerForStream(clone, mirrorStreams[0])
+
+  let allowMirror = false
+  const requestBlock = mirrorPeer._requestBlock
+  mirrorPeer._requestBlock = function () {
+    if (!allowMirror) return false
+    return requestBlock.apply(this, arguments)
+  }
+
+  t.teardown(() => {
+    mirrorPeer._requestBlock = requestBlock
+  })
+
+  const block = clone.get(0)
+  await waitForInflightBlockOnPeer(clone, slowPeer)
+
+  allowMirror = true
+  await destroyStreams([slowWriterStream, slowCloneStream])
+
+  t.alike(
+    await withTimeout(block, 1000, 'block did not resume after peer close'),
+    b4a.from('block-0')
+  )
+})
+
 test('closing idle multiplexed stream does not update all peers', async function (t) {
   const n1 = new NoiseSecretStream(true)
   const n2 = new NoiseSecretStream(false)
@@ -852,6 +898,50 @@ test('closing idle multiplexed stream does not update all peers', async function
   ])
 
   t.is(updates, 0)
+})
+
+test('closing idle peer schedules pending range on remaining peer', async function (t) {
+  const writer = await create(t)
+  const batch = []
+  for (let i = 0; i < 32; i++) batch.push('block-' + i)
+  await writer.append(batch)
+
+  const sparse = await create(t, writer.key)
+  const clone = await create(t, writer.key)
+
+  const writerStreams = replicate(writer, clone, t, { teardown: false })
+  const sparseStreams = replicate(sparse, clone, t, { teardown: false })
+
+  t.teardown(() => destroyStreams(writerStreams))
+  t.teardown(() => destroyStreams(sparseStreams))
+
+  await clone.update({ wait: true })
+  await eventFlush()
+
+  const writerPeer = findPeerForStream(clone, writerStreams[0])
+
+  let allowRange = false
+  const requestRange = writerPeer._requestRange
+  writerPeer._requestRange = function () {
+    if (!allowRange) return false
+    return requestRange.apply(this, arguments)
+  }
+
+  t.teardown(() => {
+    writerPeer._requestRange = requestRange
+  })
+
+  const download = clone.download({ start: 0, end: writer.length })
+
+  await new Promise((resolve) => setTimeout(resolve, 100))
+  t.is(clone.core.replicator._inflight.idle, true, 'range has no inflight requests yet')
+
+  allowRange = true
+  await destroyStreams(sparseStreams)
+
+  await withTimeout(download.done(), 500, 'download did not resume after peer close')
+
+  t.is(clone.contiguousLength, writer.length)
 })
 
 test('destroying a stream and re-replicating works', async function (t) {
@@ -2953,6 +3043,73 @@ async function createAndDownload(t, core) {
   replicate(core, b, t, { teardown: false })
   await b.download({ start: 0, end: core.length }).done()
   return b
+}
+
+function findPeerForStream(core, remoteStream) {
+  for (const peer of core.core.replicator.peers) {
+    if (b4a.equals(peer.stream.remotePublicKey, remoteStream.publicKey)) return peer
+  }
+
+  throw new Error('peer not found')
+}
+
+async function waitForPeerForStream(core, remoteStream) {
+  const deadline = Date.now() + 5000
+
+  while (Date.now() < deadline) {
+    for (const peer of core.core.replicator.peers) {
+      if (b4a.equals(peer.stream.remotePublicKey, remoteStream.publicKey)) return peer
+    }
+
+    await new Promise((resolve) => setImmediate(resolve))
+  }
+
+  throw new Error('peer not found')
+}
+
+async function waitForInflightBlockOnPeer(core, peer) {
+  const deadline = Date.now() + 1000
+
+  while (Date.now() < deadline) {
+    const req = core.core.replicator._inflight._requests.find((req) => {
+      return req && req.peer === peer && req.block
+    })
+
+    if (req) return req
+
+    await new Promise((resolve) => setImmediate(resolve))
+  }
+
+  throw new Error('block request was not inflight on expected peer')
+}
+
+async function withTimeout(promise, ms, message) {
+  let timeout = null
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((resolve, reject) => {
+        timeout = setTimeout(() => reject(new Error(message)), ms)
+      })
+    ])
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+function destroyStreams(streams) {
+  return Promise.all(
+    streams.map((s) => {
+      if (s.destroyed) return null
+
+      return new Promise((resolve) => {
+        s.on('error', () => {})
+        s.on('close', resolve)
+        s.destroy()
+      })
+    })
+  )
 }
 
 async function waitForRequestBlock(core) {

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -802,6 +802,7 @@ test('closing peer with inflight block reschedules on remaining peer', async fun
   await mirror.download({ start: 0, end: writer.length }).done()
 
   const clone = await create(t, writer.key)
+  const cloneAppend = new Promise((resolve) => clone.once('append', resolve))
 
   const writerPeerWait = new Promise((resolve) => clone.once('peer-add', resolve))
   const writerStreams = replicate(writer, clone, t, { keepAlive: true })
@@ -812,7 +813,7 @@ test('closing peer with inflight block reschedules on remaining peer', async fun
   t.teardown(() => unreplicate(mirrorStreams))
   const mirrorPeer = await mirrorPeerWait
 
-  await clone.update({ wait: true })
+  await cloneAppend
   await eventFlush()
 
   mirrorPeer.paused = true
@@ -903,6 +904,7 @@ test('closing idle peer schedules pending range on remaining peer', async functi
 
   const sparse = await create(t, writer.key)
   const clone = await create(t, writer.key)
+  const cloneAppend = new Promise((resolve) => clone.once('append', resolve))
 
   const writerPeerWait = new Promise((resolve) => clone.once('peer-add', resolve))
   replicate(writer, clone, t)
@@ -912,7 +914,7 @@ test('closing idle peer schedules pending range on remaining peer', async functi
   const sparseStreams = replicate(sparse, clone, t)
   const sparsePeer = await sparsePeerWait
 
-  await clone.update({ wait: true })
+  await cloneAppend
   await eventFlush()
 
   writerPeer.paused = true

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -793,6 +793,67 @@ test('multiplexing multiple times over the same stream', async function (t) {
   s3.destroy()
 })
 
+test('closing idle multiplexed stream does not update all peers', async function (t) {
+  const n1 = new NoiseSecretStream(true)
+  const n2 = new NoiseSecretStream(false)
+
+  n1.rawStream.pipe(n2.rawStream).pipe(n1.rawStream)
+
+  const cores = []
+  const clones = []
+
+  for (let i = 0; i < 4; i++) {
+    const core = await create(t)
+    await core.append('block-' + i)
+
+    const clone = await create(t, core.key)
+
+    core.replicate(n1, { keepAlive: true })
+    clone.replicate(n2, { keepAlive: true })
+
+    cores.push(core)
+    clones.push(clone)
+  }
+
+  for (const clone of clones) await clone.get(0)
+
+  await eventFlush()
+
+  for (let i = 0; i < cores.length; i++) {
+    t.is(cores[i].peers.length, 1)
+    t.is(clones[i].peers.length, 1)
+  }
+
+  let updates = 0
+  const restore = []
+  for (const core of cores.concat(clones)) {
+    const replicator = core.core.replicator
+    const updateAll = replicator.updateAll
+    restore.push(() => {
+      replicator.updateAll = updateAll
+    })
+
+    replicator.updateAll = function () {
+      updates++
+      return updateAll.apply(this, arguments)
+    }
+  }
+
+  t.teardown(() => {
+    for (const fn of restore) fn()
+  })
+
+  n1.destroy()
+  n2.destroy()
+
+  await Promise.all([
+    new Promise((resolve) => n1.once('close', resolve)),
+    new Promise((resolve) => n2.once('close', resolve))
+  ])
+
+  t.is(updates, 0)
+})
+
 test('destroying a stream and re-replicating works', async function (t) {
   const core = await create(t)
 

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -817,21 +817,16 @@ test('closing peer with inflight block reschedules on remaining peer', async fun
   await clone.update({ wait: true })
   await eventFlush()
 
-  let allowMirror = false
-  const requestBlock = mirrorPeer._requestBlock
-  mirrorPeer._requestBlock = function () {
-    if (!allowMirror) return false
-    return requestBlock.apply(this, arguments)
-  }
+  mirrorPeer.paused = true
 
   t.teardown(() => {
-    mirrorPeer._requestBlock = requestBlock
+    mirrorPeer.paused = false
   })
 
   const block = clone.get(0)
   await waitForInflightBlockOnPeer(clone, slowPeer)
 
-  allowMirror = true
+  mirrorPeer.paused = false
   await unreplicate([slowWriterStream, slowCloneStream])
 
   t.alike(
@@ -907,15 +902,10 @@ test('closing idle peer schedules pending range on remaining peer', async functi
   await clone.update({ wait: true })
   await eventFlush()
 
-  let allowRange = false
-  const requestRange = writerPeer._requestRange
-  writerPeer._requestRange = function () {
-    if (!allowRange) return false
-    return requestRange.apply(this, arguments)
-  }
+  writerPeer.paused = true
 
   t.teardown(() => {
-    writerPeer._requestRange = requestRange
+    writerPeer.paused = false
   })
 
   const download = clone.download({ start: 0, end: writer.length })
@@ -923,7 +913,7 @@ test('closing idle peer schedules pending range on remaining peer', async functi
   await new Promise((resolve) => setTimeout(resolve, 100))
   t.is(clone.core.replicator._inflight.idle, true, 'range has no inflight requests yet')
 
-  allowRange = true
+  writerPeer.paused = false
   await unreplicate(sparseStreams)
 
   await withTimeout(download.done(), 500, 'download did not resume after peer close')

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -897,7 +897,9 @@ test('closing idle peer schedules pending range on remaining peer', async functi
   replicate(writer, clone, t)
   const writerPeer = await writerPeerWait
 
+  const sparsePeerWait = new Promise((resolve) => clone.once('peer-add', resolve))
   const sparseStreams = replicate(sparse, clone, t)
+  const sparsePeer = await sparsePeerWait
 
   await clone.update({ wait: true })
   await eventFlush()
@@ -913,8 +915,12 @@ test('closing idle peer schedules pending range on remaining peer', async functi
   await new Promise((resolve) => setTimeout(resolve, 100))
   t.is(clone.core.replicator._inflight.idle, true, 'range has no inflight requests yet')
 
+  const peerRemoved = new Promise((resolve) => clone.once('peer-remove', resolve))
+
   writerPeer.paused = false
   await unreplicate(sparseStreams)
+
+  t.is(await peerRemoved, sparsePeer)
 
   await withTimeout(download.done(), 500, 'download did not resume after peer close')
 

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -811,7 +811,7 @@ test('closing peer with inflight block reschedules on remaining peer', async fun
 
   const mirrorPeerWait = new Promise((resolve) => clone.once('peer-add', resolve))
   const mirrorStreams = replicate(mirror, clone, t, { keepAlive: true, teardown: false })
-  t.teardown(() => destroyStreams(mirrorStreams))
+  t.teardown(() => unreplicate(mirrorStreams))
   const mirrorPeer = await mirrorPeerWait
 
   await clone.update({ wait: true })
@@ -832,7 +832,7 @@ test('closing peer with inflight block reschedules on remaining peer', async fun
   await waitForInflightBlockOnPeer(clone, slowPeer)
 
   allowMirror = true
-  await destroyStreams([slowWriterStream, slowCloneStream])
+  await unreplicate([slowWriterStream, slowCloneStream])
 
   t.alike(
     await withTimeout(block, 1000, 'block did not resume after peer close'),
@@ -899,7 +899,7 @@ test('closing idle peer schedules pending range on remaining peer', async functi
   const clone = await create(t, writer.key)
 
   const writerPeerWait = new Promise((resolve) => clone.once('peer-add', resolve))
-  const writerStreams = replicate(writer, clone, t)
+  replicate(writer, clone, t)
   const writerPeer = await writerPeerWait
 
   const sparseStreams = replicate(sparse, clone, t)
@@ -924,7 +924,7 @@ test('closing idle peer schedules pending range on remaining peer', async functi
   t.is(clone.core.replicator._inflight.idle, true, 'range has no inflight requests yet')
 
   allowRange = true
-  await destroyStreams(sparseStreams)
+  await unreplicate(sparseStreams)
 
   await withTimeout(download.done(), 500, 'download did not resume after peer close')
 
@@ -3061,20 +3061,6 @@ async function withTimeout(promise, ms, message) {
   } finally {
     clearTimeout(timeout)
   }
-}
-
-function destroyStreams(streams) {
-  return Promise.all(
-    streams.map((s) => {
-      if (s.destroyed) return null
-
-      return new Promise((resolve) => {
-        s.on('error', () => {})
-        s.on('close', resolve)
-        s.destroy()
-      })
-    })
-  )
 }
 
 async function waitForRequestBlock(core) {

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -841,10 +841,7 @@ test('closing peer with inflight block reschedules on remaining peer', async fun
   const block = clone.get(0)
   await uploaded
 
-  t.alike(
-    await withTimeout(block, 1000, 'block did not resume after peer close'),
-    b4a.from('block-0')
-  )
+  t.alike(await block, b4a.from('block-0'))
 })
 
 test('closing idle multiplexed stream does not update all peers', async function (t) {
@@ -935,7 +932,7 @@ test('closing idle peer schedules pending range on remaining peer', async functi
 
   t.is(await peerRemoved, sparsePeer)
 
-  await withTimeout(download.done(), 500, 'download did not resume after peer close')
+  await download.done()
 
   t.is(clone.contiguousLength, writer.length)
 })
@@ -3039,21 +3036,6 @@ async function createAndDownload(t, core) {
   replicate(core, b, t, { teardown: false })
   await b.download({ start: 0, end: core.length }).done()
   return b
-}
-
-async function withTimeout(promise, ms, message) {
-  let timeout = null
-
-  try {
-    return await Promise.race([
-      promise,
-      new Promise((resolve, reject) => {
-        timeout = setTimeout(() => reject(new Error(message)), ms)
-      })
-    ])
-  } finally {
-    clearTimeout(timeout)
-  }
 }
 
 async function waitForRequestBlock(core) {

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -844,55 +844,6 @@ test('closing peer with inflight block reschedules on remaining peer', async fun
   t.alike(await block, b4a.from('block-0'))
 })
 
-test('closing idle multiplexed stream does not update all peers', async function (t) {
-  const writer = await create(t)
-  await writer.append('block')
-
-  const clone = await create(t, writer.key)
-  const streams = []
-
-  for (let i = 0; i < 3; i++) {
-    const peer = new Promise((resolve) => clone.once('peer-add', resolve))
-    streams.push(replicate(writer, clone, t, { keepAlive: true }))
-    await peer
-  }
-
-  await clone.get(0)
-  await eventFlush()
-
-  t.is(clone.peers.length, 3, 'clone has multiple peers')
-
-  const replicator = clone.core.replicator
-  const updateAll = replicator.updateAll
-  const updatePeer = replicator._updatePeer
-
-  let updates = 0
-  let peerScans = 0
-
-  replicator.updateAll = function () {
-    updates++
-    return updateAll.apply(this, arguments)
-  }
-
-  replicator._updatePeer = function () {
-    peerScans++
-    return updatePeer.apply(this, arguments)
-  }
-
-  t.teardown(() => {
-    replicator.updateAll = updateAll
-    replicator._updatePeer = updatePeer
-  })
-
-  const peerRemoved = new Promise((resolve) => clone.once('peer-remove', resolve))
-  await unreplicate(streams[0])
-  await peerRemoved
-
-  t.is(clone.peers.length, 2, 'clone still has remaining peers')
-  t.is(updates, 0)
-  t.is(peerScans, 0)
-})
-
 test('closing idle peer schedules pending range on remaining peer', async function (t) {
   const writer = await create(t)
   const batch = []

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -816,6 +816,7 @@ test('closing peer with inflight block reschedules on remaining peer', async fun
   await cloneAppend
   await eventFlush()
 
+  // Force the initial block request onto the writer so closing it exercises rescheduling.
   mirrorPeer.paused = true
 
   t.teardown(() => {

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -840,64 +840,52 @@ test('closing peer with inflight block reschedules on remaining peer', async fun
 })
 
 test('closing idle multiplexed stream does not update all peers', async function (t) {
-  const n1 = new NoiseSecretStream(true)
-  const n2 = new NoiseSecretStream(false)
+  const writer = await create(t)
+  await writer.append('block')
 
-  n1.rawStream.pipe(n2.rawStream).pipe(n1.rawStream)
+  const clone = await create(t, writer.key)
+  const streams = []
 
-  const cores = []
-  const clones = []
-
-  for (let i = 0; i < 4; i++) {
-    const core = await create(t)
-    await core.append('block-' + i)
-
-    const clone = await create(t, core.key)
-
-    core.replicate(n1, { keepAlive: true })
-    clone.replicate(n2, { keepAlive: true })
-
-    cores.push(core)
-    clones.push(clone)
+  for (let i = 0; i < 3; i++) {
+    const peer = new Promise((resolve) => clone.once('peer-add', resolve))
+    streams.push(replicate(writer, clone, t, { keepAlive: true }))
+    await peer
   }
 
-  for (const clone of clones) await clone.get(0)
-
+  await clone.get(0)
   await eventFlush()
 
-  for (let i = 0; i < cores.length; i++) {
-    t.is(cores[i].peers.length, 1)
-    t.is(clones[i].peers.length, 1)
-  }
+  t.is(clone.peers.length, 3, 'clone has multiple peers')
+
+  const replicator = clone.core.replicator
+  const updateAll = replicator.updateAll
+  const updatePeer = replicator._updatePeer
 
   let updates = 0
-  const restore = []
-  for (const core of cores.concat(clones)) {
-    const replicator = core.core.replicator
-    const updateAll = replicator.updateAll
-    restore.push(() => {
-      replicator.updateAll = updateAll
-    })
+  let peerScans = 0
 
-    replicator.updateAll = function () {
-      updates++
-      return updateAll.apply(this, arguments)
-    }
+  replicator.updateAll = function () {
+    updates++
+    return updateAll.apply(this, arguments)
+  }
+
+  replicator._updatePeer = function () {
+    peerScans++
+    return updatePeer.apply(this, arguments)
   }
 
   t.teardown(() => {
-    for (const fn of restore) fn()
+    replicator.updateAll = updateAll
+    replicator._updatePeer = updatePeer
   })
 
-  n1.destroy()
-  n2.destroy()
+  const peerRemoved = new Promise((resolve) => clone.once('peer-remove', resolve))
+  await unreplicate(streams[0])
+  await peerRemoved
 
-  await Promise.all([
-    new Promise((resolve) => n1.once('close', resolve)),
-    new Promise((resolve) => n2.once('close', resolve))
-  ])
-
+  t.is(clone.peers.length, 2, 'clone still has remaining peers')
   t.is(updates, 0)
+  t.is(peerScans, 0)
 })
 
 test('closing idle peer schedules pending range on remaining peer', async function (t) {

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -804,17 +804,18 @@ test('closing peer with inflight block reschedules on remaining peer', async fun
   const clone = await create(t, writer.key)
 
   const [slowWriterStream, slowCloneStream] = makeStreamPair(t, { latency: [200, 200] })
+  const slowPeerWait = new Promise((resolve) => clone.once('peer-add', resolve))
   writer.replicate(slowWriterStream, { keepAlive: true })
   clone.replicate(slowCloneStream, { keepAlive: true })
+  const slowPeer = await slowPeerWait
 
+  const mirrorPeerWait = new Promise((resolve) => clone.once('peer-add', resolve))
   const mirrorStreams = replicate(mirror, clone, t, { keepAlive: true, teardown: false })
   t.teardown(() => destroyStreams(mirrorStreams))
+  const mirrorPeer = await mirrorPeerWait
 
   await clone.update({ wait: true })
   await eventFlush()
-
-  const slowPeer = await waitForPeerForStream(clone, slowWriterStream)
-  const mirrorPeer = await waitForPeerForStream(clone, mirrorStreams[0])
 
   let allowMirror = false
   const requestBlock = mirrorPeer._requestBlock
@@ -897,7 +898,10 @@ test('closing idle peer schedules pending range on remaining peer', async functi
   const sparse = await create(t, writer.key)
   const clone = await create(t, writer.key)
 
+  const writerPeerWait = new Promise((resolve) => clone.once('peer-add', resolve))
   const writerStreams = replicate(writer, clone, t, { teardown: false })
+  const writerPeer = await writerPeerWait
+
   const sparseStreams = replicate(sparse, clone, t, { teardown: false })
 
   t.teardown(() => destroyStreams(writerStreams))
@@ -905,8 +909,6 @@ test('closing idle peer schedules pending range on remaining peer', async functi
 
   await clone.update({ wait: true })
   await eventFlush()
-
-  const writerPeer = findPeerForStream(clone, writerStreams[0])
 
   let allowRange = false
   const requestRange = writerPeer._requestRange
@@ -3031,28 +3033,6 @@ async function createAndDownload(t, core) {
   replicate(core, b, t, { teardown: false })
   await b.download({ start: 0, end: core.length }).done()
   return b
-}
-
-function findPeerForStream(core, remoteStream) {
-  for (const peer of core.core.replicator.peers) {
-    if (b4a.equals(peer.stream.remotePublicKey, remoteStream.publicKey)) return peer
-  }
-
-  throw new Error('peer not found')
-}
-
-async function waitForPeerForStream(core, remoteStream) {
-  const deadline = Date.now() + 5000
-
-  while (Date.now() < deadline) {
-    for (const peer of core.core.replicator.peers) {
-      if (b4a.equals(peer.stream.remotePublicKey, remoteStream.publicKey)) return peer
-    }
-
-    await new Promise((resolve) => setImmediate(resolve))
-  }
-
-  throw new Error('peer not found')
 }
 
 async function waitForInflightBlockOnPeer(core, peer) {

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -803,11 +803,9 @@ test('closing peer with inflight block reschedules on remaining peer', async fun
 
   const clone = await create(t, writer.key)
 
-  const [slowWriterStream, slowCloneStream] = makeStreamPair(t, { latency: [200, 200] })
-  const slowPeerWait = new Promise((resolve) => clone.once('peer-add', resolve))
-  writer.replicate(slowWriterStream, { keepAlive: true })
-  clone.replicate(slowCloneStream, { keepAlive: true })
-  const slowPeer = await slowPeerWait
+  const writerPeerWait = new Promise((resolve) => clone.once('peer-add', resolve))
+  const writerStreams = replicate(writer, clone, t, { keepAlive: true })
+  const writerPeer = await writerPeerWait
 
   const mirrorPeerWait = new Promise((resolve) => clone.once('peer-add', resolve))
   const mirrorStreams = replicate(mirror, clone, t, { keepAlive: true, teardown: false })
@@ -823,11 +821,24 @@ test('closing peer with inflight block reschedules on remaining peer', async fun
     mirrorPeer.paused = false
   })
 
-  const block = clone.get(0)
-  await waitForInflightBlockOnPeer(clone, slowPeer)
+  const peerRemoved = new Promise((resolve) => clone.once('peer-remove', resolve))
+  const uploaded = new Promise((resolve, reject) => {
+    writer.once('upload', async function (index) {
+      try {
+        t.is(index, 0)
 
-  mirrorPeer.paused = false
-  await unreplicate([slowWriterStream, slowCloneStream])
+        mirrorPeer.paused = false
+        await unreplicate(writerStreams)
+        t.is(await peerRemoved, writerPeer)
+        resolve()
+      } catch (err) {
+        reject(err)
+      }
+    })
+  })
+
+  const block = clone.get(0)
+  await uploaded
 
   t.alike(
     await withTimeout(block, 1000, 'block did not resume after peer close'),
@@ -3026,22 +3037,6 @@ async function createAndDownload(t, core) {
   replicate(core, b, t, { teardown: false })
   await b.download({ start: 0, end: core.length }).done()
   return b
-}
-
-async function waitForInflightBlockOnPeer(core, peer) {
-  const deadline = Date.now() + 1000
-
-  while (Date.now() < deadline) {
-    const req = core.core.replicator._inflight._requests.find((req) => {
-      return req && req.peer === peer && req.block
-    })
-
-    if (req) return req
-
-    await new Promise((resolve) => setImmediate(resolve))
-  }
-
-  throw new Error('block request was not inflight on expected peer')
 }
 
 async function withTimeout(promise, ms, message) {


### PR DESCRIPTION
Adds coverage for peer-close scheduling paths:

- inflight block requests resume on a remaining peer after the requested peer closes
- pending range downloads resume on a remaining peer after an idle peer closes

This PR is test-only. The idle-close updateAll() optimization was moved to a follow-up branch.