### PR TITLE
Limit # of peers used in non-primary update

### DIFF
--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -47,6 +47,7 @@ const DEFAULT_MAX_INFLIGHT = [16, 512]
 const SCALE_LATENCY = 50
 const NOT_DOWNLOADING_SLACK = (20000 + Math.random() * 20000) | 0
 const MAX_PEERS_UPGRADE = 3
+const MAX_PEERS_NON_PRIMARY = 50
 const LAST_BLOCKS = 256
 
 const MAX_RANGES = 64
@@ -3039,10 +3040,13 @@ module.exports = class Replicator {
       return
     }
 
+    let tries = 0
     for (const peer of peers.restart()) {
+      if (tries >= MAX_PEERS_NON_PRIMARY) break
       if (this._updatePeerNonPrimary(peer) === true) {
         peers.requeue()
       }
+      tries++
     }
 
     this._checkUpgradeIfAvailable()


### PR DESCRIPTION
Reduces messages while still allowing ranges etc to be bumped with random peers.

Non-primary updates are limited to a constant `MAX_PEERS_NON_PRIMARY` which is current set to be `50`.