### PR TITLE
Remove unused `pointer` variable

### DIFF
--- a/lib/session-state.js
+++ b/lib/session-state.js
@@ -306,8 +306,6 @@ class SessionState {
       }
 
       if (this.isDefault() && this.core.header.group) {
-        const { pointer } = this.core.header.group
-
         const tx = await this.createWriteBatch()
         this.updateGroupIndex(tx, tree)
         await tx.flush()


### PR DESCRIPTION
Removal of an unused variable that wasn't caught by linting.