### PR TITLE
Fix pending update on peer close

### DIFF
--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -2460,7 +2460,12 @@ module.exports = class Replicator {
     }
 
     this._onpeerupdate(false, peer)
-    if (inflight) this.updateAll()
+    if (inflight) {
+      this.updateAll()
+    } else {
+      this._checkUpgradeIfAvailable()
+      this._maybeResolveIfAvailableRanges()
+    }
   }
 
   _queueBlock(b) {

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -956,6 +956,41 @@ test('findingPeers + done makes update return false if no peers', async function
   t.is(await u, false)
 })
 
+test('update wait resolves when unsynced peer closes without inflight', async function (t) {
+  t.plan(2)
+
+  const a = await create(t)
+  const b = await create(t, a.key)
+
+  let streams = null
+  let update = null
+
+  const peerAdded = new Promise((resolve) => {
+    b.once('peer-add', () => {
+      update = b.update({ wait: true })
+
+      Promise.resolve().then(() => {
+        resolve(unreplicate(streams))
+      })
+    })
+  })
+
+  streams = replicate(a, b, t, { teardown: false })
+
+  await peerAdded
+
+  let timer = null
+  const timeout = new Promise((resolve) => {
+    timer = setTimeout(resolve, 250, null)
+  })
+
+  const result = await Promise.race([update, timeout])
+  clearTimeout(timer)
+
+  t.not(result, null, 'update resolved')
+  t.is(result, false, 'no upgrade was available')
+})
+
 test.skip('can disable downloading from a peer', async function (t) {
   const a = await create(t)
 


### PR DESCRIPTION
The regression test covers the pending update waiter path. The `_maybeResolveIfAvailableRanges()` call is included to preserve the completion checks that `updateAll()` used to run on peer removal. Current behaviour in main can introduce stalling behaviour and other un-intended side-effects when the completion checks are not invoked

Found from the perf work at  https://github.com/holepunchto/hypercore/pull/814 while reviewing https://github.com/holepunchto/hypercore/pull/815 
