### PR TITLE
Remove ifAvailable range downloads

### DIFF
--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -233,13 +233,12 @@ class RangeBatchRequest extends Attachable {
 }
 
 class RangeRequest extends Attachable {
-  constructor(replicator, ranges, start, end, linear, ifAvailable, blocks) {
+  constructor(replicator, ranges, start, end, linear, blocks) {
     super(replicator)
 
     this.start = start
     this.end = end
     this.linear = linear
-    this.ifAvailable = ifAvailable
     this.blocks = blocks
     this.ranges = ranges
     this.batches = []
@@ -2230,14 +2229,7 @@ module.exports = class Replicator {
 
   addRange(
     session,
-    {
-      start = 0,
-      end = -1,
-      length = toLength(start, end),
-      blocks = null,
-      linear = false,
-      ifAvailable = false
-    } = {}
+    { start = 0, end = -1, length = toLength(start, end), blocks = null, linear = false } = {}
   ) {
     if (blocks !== null) {
       // if using blocks, start, end just acts as frames around the blocks array
@@ -2251,7 +2243,6 @@ module.exports = class Replicator {
       start,
       length === -1 ? -1 : start + length,
       linear,
-      ifAvailable,
       blocks
     )
 
@@ -2464,7 +2455,6 @@ module.exports = class Replicator {
       this.updateAll()
     } else {
       this._checkUpgradeIfAvailable()
-      this._maybeResolveIfAvailableRanges()
     }
   }
 
@@ -2656,23 +2646,6 @@ module.exports = class Replicator {
     }
 
     if (this._inflight.idle || updateAll) this.updateAll()
-  }
-
-  _maybeResolveIfAvailableRanges() {
-    if (this._ifAvailable > 0 || !this._inflight.idle || !this._ranges.length) return
-
-    for (let i = 0; i < this.peers.length; i++) {
-      if (this.peers[i].dataProcessing > 0) return
-    }
-
-    for (let i = 0; i < this._ranges.length; i++) {
-      const r = this._ranges[i]
-
-      if (r.ifAvailable) {
-        this._resolveRangeRequest(r)
-        i--
-      }
-    }
   }
 
   _clearRequest(peer, req) {
@@ -3025,7 +2998,6 @@ module.exports = class Replicator {
     }
 
     this._checkUpgradeIfAvailable()
-    this._maybeResolveIfAvailableRanges()
   }
 
   updateAll() {
@@ -3053,7 +3025,6 @@ module.exports = class Replicator {
     }
 
     this._checkUpgradeIfAvailable()
-    this._maybeResolveIfAvailableRanges()
   }
 
   onpeerdestroy() {

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -1137,86 +1137,6 @@ test.skip('non-sparse replication', async function (t) {
   t.is(contiguousLength, b.length)
 })
 
-test('download blocks if available', async function (t) {
-  const a = await create(t)
-  const b = await create(t, a.key)
-
-  replicate(a, b, t)
-
-  await a.append(['a', 'b', 'c', 'd', 'e'])
-  await eventFlush()
-
-  let d = 0
-  b.on('download', () => d++)
-
-  const r = b.download({ blocks: [1, 3, 6], ifAvailable: true })
-  await r.done()
-
-  t.is(d, 2)
-})
-
-test('download range if available', async function (t) {
-  const a = await create(t)
-  const b = await create(t, a.key)
-
-  replicate(a, b, t)
-
-  await a.append(['a', 'b', 'c', 'd', 'e'])
-  await eventFlush()
-
-  let d = 0
-  b.on('download', () => d++)
-
-  const r = b.download({ start: 2, end: 6, ifAvailable: true })
-  await r.done()
-
-  t.is(d, 3)
-})
-
-test('download blocks if available, destroy midway', async function (t) {
-  const a = await create(t)
-  const b = await create(t, a.key)
-
-  const s = replicate(a, b, t, { teardown: false })
-
-  await a.append(['a', 'b', 'c', 'd', 'e'])
-  await eventFlush()
-
-  let d = 0
-  b.on('download', () => {
-    if (d++ === 0) unreplicate(s)
-  })
-
-  const r = b.download({ blocks: [1, 3, 6], ifAvailable: true })
-  await r.done()
-
-  t.pass('range resolved')
-})
-
-test('download blocks available from when only a partial set is available', async function (t) {
-  const a = await create(t)
-  const b = await create(t, a.key)
-  const c = await create(t, a.key)
-
-  replicate(a, b, t)
-  replicate(b, c, t)
-
-  await a.append(['a', 'b', 'c', 'd', 'e'])
-  await eventFlush()
-
-  await b.get(2)
-  await b.get(3)
-
-  const r = c.download({ start: 0, end: -1, ifAvailable: true })
-  await r.done()
-
-  t.ok(!(await c.has(0)))
-  t.ok(!(await c.has(1)))
-  t.ok(await c.has(2))
-  t.ok(await c.has(3))
-  t.ok(!(await c.has(4)))
-})
-
 test('big download range', async function (t) {
   const a = await create(t)
   const b = await create(t, a.key)
@@ -1273,18 +1193,6 @@ test('big download range (non contig)', async function (t) {
 
   await r3.done()
   t.pass('d done')
-})
-
-test('download range resolves immediately if no peers', async function (t) {
-  const a = await create(t)
-  const b = await create(t, a.key)
-
-  // no replication
-
-  const r = b.download({ start: 0, end: 5, ifAvailable: true })
-  await r.done()
-
-  t.pass('range resolved')
 })
 
 test('download available blocks on non-sparse update', async function (t) {


### PR DESCRIPTION
Remove the 'legacy' `download(..., { ifAvailable: true })` range mode.
Removing it keeps range downloads on the normal request lifecycle and avoids preserving a fragile special case.