### PR TITLE
feat: Include head with ongroupupdate

### DIFF
--- a/lib/session-state.js
+++ b/lib/session-state.js
@@ -224,7 +224,11 @@ class SessionState {
 
     tx.deleteGroupUpdate(pointer, this.core.header.tree.timestamp)
     tx.putGroupUpdate(pointer, tree.timestamp, this.core.header.key)
-    this.core.ongroupupdate(this.core.header.group.key, { key: this.core.key, length: tree.length })
+    this.core.ongroupupdate(this.core.header.group.key, {
+      key: this.core.key,
+      length: tree.length,
+      fork: tree.fork
+    })
   }
 
   _clearActiveBatch() {

--- a/lib/session-state.js
+++ b/lib/session-state.js
@@ -224,7 +224,7 @@ class SessionState {
 
     tx.deleteGroupUpdate(pointer, this.core.header.tree.timestamp)
     tx.putGroupUpdate(pointer, tree.timestamp, this.core.header.key)
-    this.core.ongroupupdate(this.core.header.group.key)
+    this.core.ongroupupdate(this.core.header.group.key, { key: this.core.key, length: tree.length })
   }
 
   _clearActiveBatch() {

--- a/test/groups.js
+++ b/test/groups.js
@@ -94,7 +94,8 @@ test('groups - core hook - ongroupupdate() w/head', async function (t) {
   t.alike(events, [
     {
       key: a.core.key,
-      length: 1
+      length: 1,
+      fork: 0
     }
   ])
 
@@ -104,11 +105,13 @@ test('groups - core hook - ongroupupdate() w/head', async function (t) {
   t.alike(events, [
     {
       key: a.core.key,
-      length: 1
+      length: 1,
+      fork: 0
     },
     {
       key: a.core.key,
-      length: 2
+      length: 2,
+      fork: 0
     }
   ])
 })
@@ -144,15 +147,86 @@ test('groups - core hook - ongroupupdate() w/head multiple', async function (t) 
   t.alike(events, [
     {
       key: a.core.key,
-      length: 1
+      length: 1,
+      fork: 0
     },
     {
       key: b.core.key,
-      length: 1
+      length: 1,
+      fork: 0
     },
     {
       key: a.core.key,
-      length: 2
+      length: 2,
+      fork: 0
+    }
+  ])
+})
+
+test('groups - core hook - ongroupupdate() w/head and fork', async function (t) {
+  t.plan(10)
+  const a = await create(t)
+
+  const groupKey = b4a.alloc(32, 1)
+  const events = []
+
+  a.core.ongroupupdate = (key, head) => {
+    t.alike(key, groupKey, 'got group key in event')
+    events.push(head)
+  }
+
+  await a.setGroup(groupKey)
+  t.alike(a.core.header.group.key, b4a.alloc(32, 1), 'a has a group')
+
+  await a.append('beep')
+
+  t.is(events.length, 1)
+  t.alike(events, [
+    {
+      key: a.core.key,
+      length: 1,
+      fork: 0
+    }
+  ])
+
+  await a.truncate(0)
+
+  t.is(events.length, 2)
+  t.alike(
+    events,
+    [
+      {
+        key: a.core.key,
+        length: 1,
+        fork: 0
+      },
+      {
+        key: a.core.key,
+        length: 0,
+        fork: 1
+      }
+    ],
+    'forked event'
+  )
+
+  await a.append('beep')
+
+  t.is(events.length, 3)
+  t.alike(events, [
+    {
+      key: a.core.key,
+      length: 1,
+      fork: 0
+    },
+    {
+      key: a.core.key,
+      length: 0,
+      fork: 1
+    },
+    {
+      key: a.core.key,
+      length: 1,
+      fork: 1
     }
   ])
 })

--- a/test/groups.js
+++ b/test/groups.js
@@ -72,3 +72,87 @@ test('groups - core hook - ongroupupdate()', async function (t) {
 
   await a.append('beep')
 })
+
+test('groups - core hook - ongroupupdate() w/head', async function (t) {
+  t.plan(7)
+  const a = await create(t)
+
+  const groupKey = b4a.alloc(32, 1)
+  const events = []
+
+  a.core.ongroupupdate = (key, head) => {
+    t.alike(key, groupKey, 'got group key in event')
+    events.push(head)
+  }
+
+  await a.setGroup(groupKey)
+  t.alike(a.core.header.group.key, b4a.alloc(32, 1), 'a has a group')
+
+  await a.append('beep')
+
+  t.is(events.length, 1)
+  t.alike(events, [
+    {
+      key: a.core.key,
+      length: 1
+    }
+  ])
+
+  await a.append('beep')
+
+  t.is(events.length, 2)
+  t.alike(events, [
+    {
+      key: a.core.key,
+      length: 1
+    },
+    {
+      key: a.core.key,
+      length: 2
+    }
+  ])
+})
+
+test('groups - core hook - ongroupupdate() w/head multiple', async function (t) {
+  t.plan(7)
+  const a = await create(t)
+  const b = await create(t)
+
+  const groupKey = b4a.alloc(32, 1)
+  const events = []
+
+  a.core.ongroupupdate = (key, head) => {
+    t.alike(key, groupKey, 'got group key in event')
+    events.push(head)
+  }
+
+  b.core.ongroupupdate = (key, head) => {
+    t.alike(key, groupKey, 'got group key in event')
+    events.push(head)
+  }
+
+  await a.setGroup(groupKey)
+  await b.setGroup(groupKey)
+  t.alike(a.core.header.group.key, b4a.alloc(32, 1), 'a has a group')
+  t.alike(b.core.header.group.key, b4a.alloc(32, 1), 'b has a group')
+
+  await a.append('beep')
+  await b.append('beep')
+  await a.append('beep')
+
+  t.is(events.length, 3)
+  t.alike(events, [
+    {
+      key: a.core.key,
+      length: 1
+    },
+    {
+      key: b.core.key,
+      length: 1
+    },
+    {
+      key: a.core.key,
+      length: 2
+    }
+  ])
+})


### PR DESCRIPTION
Passes up current key and length of updated core
