### PR TITLE
emit `peer-synchronize` when a peer's synchronize message is processed

### DIFF
--- a/README.md
+++ b/README.md
@@ -763,6 +763,10 @@ Emitted when a new connection has been established with a peer.
 
 Emitted when a peer's connection has been closed.
 
+#### `core.on('peer-synchronize', peer)`
+
+Emitted when a synchronize message from a peer has been processed, meaning the peer's remote state (`peer.remoteLength`, `peer.remoteFork`, etc) has been updated. The first emission for a peer means its handshake has completed: `peer-add` fires before the peer has sent anything, so this is the earliest point at which the peer's remote state can be read.
+
 #### `core.on('upload', index, byteLength, peer)`
 
 Emitted when a block is uploaded to a peer.

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -807,6 +807,8 @@ class Peer {
     this.remoteHasManifest = hasManifest
     this.remoteAllowPush = allowPush
 
+    this.replicator._onpeersynchronize(this)
+
     if (this.closeIfIdle()) return
 
     this.lengthAcked = sameFork ? remoteLength : 0
@@ -3214,6 +3216,14 @@ module.exports = class Replicator {
           peer.extensions.set(ext.name, ext)
         }
       }
+    }
+  }
+
+  _onpeersynchronize(peer) {
+    const sessions = this.core.monitors
+
+    for (let i = sessions.length - 1; i >= 0; i--) {
+      sessions[i].emit('peer-synchronize', peer)
     }
   }
 

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -2937,6 +2937,25 @@ test('delayed updateAll timer doesnt keep event loop alive', async function (t) 
   t.is(r._updateAllBump, null, 'timer reset to null')
 })
 
+test('peer-synchronize is emitted when a synchronize message is processed', async function (t) {
+  const a = await create(t)
+  await a.append(['a', 'b', 'c'])
+
+  const b = await create(t, a.key)
+
+  const aSynchronized = new Promise((resolve) => a.once('peer-synchronize', resolve))
+  const bSynchronized = new Promise((resolve) => b.once('peer-synchronize', resolve))
+
+  replicate(a, b, t)
+
+  const peerOnA = await aSynchronized
+  t.is(peerOnA.remoteSynced, true, 'peer remote state is set when emitted')
+
+  const peerOnB = await bSynchronized
+  t.is(peerOnB.remoteSynced, true, 'peer remote state is set when emitted')
+  t.is(peerOnB.remoteLength, 3, 'peer remote length is known when emitted')
+})
+
 async function createAndDownload(t, core) {
   const b = await create(t, core.key)
   replicate(core, b, t, { teardown: false })


### PR DESCRIPTION
`peer-add` is emitted before a peer has sent anything, so there is currently no way to observe when a peer's remote state (`peer.remoteLength`, `peer.remoteFork`, `peer.remoteSynced`) becomes known or changes.

This PR emits a `peer-synchronize` session event, mirroring `peer-add`/`peer-remove`, after a synchronize message has updated the peer's remote state fields. The emission is placed before the `closeIfIdle()` early-return so it also fires for sessions that immediately idle-close.

The first emission for a peer marks the completion of its handshake.

No behavior change; observability only.

Use case: [CoMapeo](https://github.com/digidem/comapeo-core) tracks per-peer replication state (sync progress across a set of devices) and needs to know when a peer's length handshake has completed. We've previously been using `core.update({ wait: true })` for this, which is wrong because it resolves immediately for writable cores, resolves for all waiters when any peer supplies an upgrade, and samples at most `MAX_PEERS_UPGRADE` peers.

