### PR TITLE
Emit `clear` when a range of blocks is cleared from local storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -755,6 +755,10 @@ Emitted when the core has been appended to (i.e. has a new length / byteLength),
 
 Emitted when the core has been truncated, either locally or remotely.
 
+#### `core.on('clear', start, end)`
+
+Emitted when a range of blocks has been cleared from local storage with `core.clear()`.
+
 #### `core.on('peer-add')`
 
 Emitted when a new connection has been established with a peer.

--- a/lib/session-state.js
+++ b/lib/session-state.js
@@ -605,6 +605,10 @@ class SessionState {
         this.core.replicator.onhave(start, length, true)
 
         if (this.core.hintsChanged) await this.core.flushHints()
+
+        for (let i = this.sessions.length - 1; i >= 0; i--) {
+          this.sessions[i].emit('clear', start, end)
+        }
       }
     } finally {
       this._unlock()

--- a/test/clear.js
+++ b/test/clear.js
@@ -22,6 +22,19 @@ test('clear', async function (t) {
   await a.close()
 })
 
+test('clear emits a clear event with the cleared range', async function (t) {
+  const a = await create(t)
+  await a.append(['a', 'b', 'c'])
+
+  const cleared = new Promise((resolve) => a.once('clear', (start, end) => resolve({ start, end })))
+
+  await a.clear(1, 3)
+
+  t.alike(await cleared, { start: 1, end: 3 }, 'clear event fired with the cleared range')
+
+  await a.close()
+})
+
 test('clear + replication', async function (t) {
   const a = await create(t)
   const b = await create(t, a.key)


### PR DESCRIPTION
`append` and `truncate` emit session events, but `core.clear()` emits nothing, so there is no way to observe blocks being removed from local storage. Applications that derive state from the local bitfield (e.g. announcing what they have to other peers over a side channel) need to know when that state shrinks as well as when it grows.

This PR emits a `clear` event with the cleared range `(start, end)` after the clear has been flushed, mirroring the `truncate` event. It is emitted only from the default session state, so atomic batches and named sessions do not emit until their changes land.

No behavior change; observability only.

Use case: [CoMapeo](https://github.com/digidem/comapeo-core) peers broadcast their "haves" to each other on first connection, before replicating cores. We need to re-broadcast these haves after a clear.

- The event signature `(start, end)` matches `clear(start, end)`'s arguments. If preferred, we could follow `truncate`'s style, which could carry a richer payload, but the range is what the one known consumer needs.
