### PR TITLE
add suspend controller for replication

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,6 +20,7 @@ const inspect = require('./lib/inspect')
 const Core = require('./lib/core')
 const Info = require('./lib/info')
 const Download = require('./lib/download')
+const SuspendController = require('./lib/suspend-controller')
 const DefaultEncryption = require('./lib/default-encryption')
 const caps = require('./lib/caps')
 const Replicator = require('./lib/replicator')
@@ -1309,6 +1310,7 @@ class Hypercore extends EventEmitter {
 }
 
 module.exports = Hypercore
+module.exports.SuspendController = SuspendController
 
 function isStream(s) {
   return typeof s === 'object' && s && typeof s.pipe === 'function'
@@ -1360,6 +1362,7 @@ function initOnce(session, storage, key, opts) {
     pushOnly: !!opts.pushOnly,
     alwaysLatestBlock: !!opts.allowLatestBlock,
     inflightRange: opts.inflightRange,
+    suspendSignal: opts.suspendSignal || null,
     compat: opts.compat === true,
     force: opts.force,
     createIfMissing: opts.createIfMissing,

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -2124,8 +2124,9 @@ module.exports = class Replicator {
         peer.dataProcessing > 0 ||
         peer.syncsProcessing > 0 ||
         peer.pushProcessing > 0
-      )
+      ) {
         return true
+      }
     }
     return false
   }

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -885,6 +885,8 @@ class Peer {
   // Safe to call in the background - never fails
   async _canUpgrade(remoteLength, remoteFork) {
     if (remoteFork !== this.core.state.fork) return false
+    // upgradeable reads the merkle tree, no storage reads while suspended
+    if (this.replicator.suspended) return false
 
     if (remoteLength === 0) return true
     if (remoteLength >= this.core.state.length) return false
@@ -942,7 +944,7 @@ class Peer {
       this.remoteRequests.set(msg.id, msg)
     }
 
-    if (!this.protomux.drained || this.receiverQueue.length) {
+    if (!this.protomux.drained || this.receiverQueue.length || this.replicator.suspended) {
       this.receiverQueue.push(msg)
       return
     }
@@ -966,7 +968,7 @@ class Peer {
   }
 
   async _handleRequests() {
-    if (this.receiverBusy || this.replicator.destroyed) return
+    if (this.receiverBusy || this.replicator.destroyed || this.replicator.suspended) return
     this.receiverBusy = true
     this.protomux.cork()
 
@@ -974,7 +976,8 @@ class Peer {
       this.remoteOpened &&
       this.protomux.drained &&
       this.receiverQueue.length > 0 &&
-      !this.removed
+      !this.removed &&
+      !this.replicator.suspended
     ) {
       const msg = this.receiverQueue.shift()
       await this._handleRequest(msg)
@@ -985,6 +988,7 @@ class Peer {
   }
 
   async push(index) {
+    if (this.replicator.suspended) return
     if (!this.remoteAllowPush) return
     if (!this.remoteDownloading) return
     if (this.core.state.length <= index) return
@@ -1204,6 +1208,16 @@ class Peer {
   }
 
   async _handleData(data) {
+    // drop data while suspended, clearing the request so resume re-requests it
+    if (this.replicator.suspended) {
+      const req = data.request > 0 ? this.replicator._inflight.get(data.request) : null
+      if (req !== null && req.peer === this) {
+        this._onrequestroundtrip(req)
+        this.replicator._onnodata(this, req, 0)
+      }
+      return
+    }
+
     // always allow a fork conflict proof to be sent
     if (data.request === 0 && data.upgrade && data.upgrade.start === 0) {
       if (await this.core.checkConflict(data, this)) return
@@ -1912,7 +1926,9 @@ class Peer {
   }
 
   isActive() {
-    if (this.paused || this.removed || this.core.header.frozen) return false
+    if (this.paused || this.removed || this.replicator.suspended || this.core.header.frozen) {
+      return false
+    }
     return true
   }
 
@@ -1972,7 +1988,8 @@ module.exports = class Replicator {
       allowFork = true,
       allowPush = false,
       alwaysLatestBlock = false,
-      inflightRange = null
+      inflightRange = null,
+      suspendSignal = null
     } = {}
   ) {
     this.core = core
@@ -1985,6 +2002,7 @@ module.exports = class Replicator {
     this.destroyed = false
     this.downloading = false
     this.pushOnly = false
+    this.suspendSignal = suspendSignal
     this.activeSessions = 0
 
     this.hotswaps = new HotswapQueue()
@@ -2037,12 +2055,22 @@ module.exports = class Replicator {
     this._updateAllBump = null
     this._updateAllBound = this.updateAll.bind(this)
 
+    this._onsignalresumeBound = this._onsignalresume.bind(this)
+    if (this.suspendSignal !== null) this.suspendSignal.on('resume', this._onsignalresumeBound)
+
     const self = this
     this._onstreamclose = onstreamclose
 
     function onstreamclose() {
       self.detachFrom(this.userData)
     }
+  }
+
+  // serve requests queued while suspended and re-request dropped data,
+  // without this the machinery stays idle until unrelated traffic arrives
+  _onsignalresume() {
+    for (const peer of this.peers) peer._handleRequests().catch(safetyCatch)
+    this.updateAll()
   }
 
   setInflightRange(min, max) {
@@ -2075,6 +2103,20 @@ module.exports = class Replicator {
     if (allowPush === this.allowPush) return
     this.allowPush = allowPush
     for (const peer of this.peers) peer.sendSync()
+  }
+
+  // replication pauses both ways while the signal is suspended, peers stay
+  // connected and no storage op is issued once _replicationBusy() clears
+  get suspended() {
+    return this.suspendSignal !== null && this.suspendSignal.suspended
+  }
+
+  _replicationBusy() {
+    if (this._applyingReorg !== null) return true
+    for (const peer of this.peers) {
+      if (peer.receiverBusy || peer.dataProcessing > 0 || peer.syncsProcessing > 0) return true
+    }
+    return false
   }
 
   isAllowingPush() {
@@ -2795,7 +2837,9 @@ module.exports = class Replicator {
   }
 
   _onwant(peer, start, length, any) {
-    if (!peer.isActive()) return
+    // wants are answered from memory, and dropping them while suspended
+    // would leave the remote blind to our ranges after resume
+    if (!peer.isActive() && !this.suspended) return
 
     const contig = Math.min(this.core.state.length, this.core.header.hints.contiguousLength)
 
@@ -3133,6 +3177,10 @@ module.exports = class Replicator {
   destroy() {
     if (this.destroyed) return
     this.destroyed = true
+
+    if (this.suspendSignal !== null) {
+      this.suspendSignal.removeListener('resume', this._onsignalresumeBound)
+    }
 
     if (this._notDownloadingTimer) {
       clearTimeout(this._notDownloadingTimer)

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -973,19 +973,21 @@ class Peer {
     this.receiverBusy = true
     this.protomux.cork()
 
-    while (
-      this.remoteOpened &&
-      this.protomux.drained &&
-      this.receiverQueue.length > 0 &&
-      !this.removed &&
-      !this.replicator.suspended
-    ) {
-      const msg = this.receiverQueue.shift()
-      await this._handleRequest(msg)
+    try {
+      while (
+        this.remoteOpened &&
+        this.protomux.drained &&
+        this.receiverQueue.length > 0 &&
+        !this.removed &&
+        !this.replicator.suspended
+      ) {
+        const msg = this.receiverQueue.shift()
+        await this._handleRequest(msg)
+      }
+    } finally {
+      this.protomux.uncork()
+      this.receiverBusy = false
     }
-
-    this.protomux.uncork()
-    this.receiverBusy = false
   }
 
   async push(index) {

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -2119,7 +2119,13 @@ module.exports = class Replicator {
   get busy() {
     if (this._applyingReorg !== null) return true
     for (const peer of this.peers) {
-      if (peer.receiverBusy || peer.dataProcessing > 0 || peer.syncsProcessing > 0 || peer.pushProcessing > 0) return true
+      if (
+        peer.receiverBusy ||
+        peer.dataProcessing > 0 ||
+        peer.syncsProcessing > 0 ||
+        peer.pushProcessing > 0
+      )
+        return true
     }
     return false
   }

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -1107,6 +1107,15 @@ class Peer {
 
       // sync from now on, so safe to delete from the map
       this.remoteRequests.delete(req.msg.id)
+
+      // suspended mid-flight, after async req.fulfill(). This request was
+      // already unregistered, so falling through to the isActive() below
+      // would drop it. Putting it back for the next _handleRequests() call.
+      if (this.replicator.suspended && !this.removed && proof.block !== null) {
+        this.remoteRequests.set(req.msg.id, req.msg)
+        this.receiverQueue.push(req.msg)
+        return
+      }
     } else if (!this.remoteAllowPush) {
       // if pushing but remote disabled it, just drop it
       return

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -537,6 +537,7 @@ class Peer {
 
     this.inflight = 0
     this.dataProcessing = 0
+    this.pushProcessing = 0
 
     this.canUpgrade = true
 
@@ -1007,6 +1008,7 @@ class Peer {
     }
 
     await this.replicator._txLock.lock()
+    this.pushProcessing++
     try {
       const remoteLength = Math.max(this.remoteLength, this.pushedLength)
 
@@ -1036,6 +1038,7 @@ class Peer {
 
       await this._fulfillRequest(req, true)
     } finally {
+      this.pushProcessing--
       this.replicator._txLock.unlock()
     }
   }
@@ -2114,7 +2117,7 @@ module.exports = class Replicator {
   get busy() {
     if (this._applyingReorg !== null) return true
     for (const peer of this.peers) {
-      if (peer.receiverBusy || peer.dataProcessing > 0 || peer.syncsProcessing > 0) return true
+      if (peer.receiverBusy || peer.dataProcessing > 0 || peer.syncsProcessing > 0 || peer.pushProcessing > 0) return true
     }
     return false
   }

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -2106,12 +2106,12 @@ module.exports = class Replicator {
   }
 
   // replication pauses both ways while the signal is suspended, peers stay
-  // connected and no storage op is issued once _replicationBusy() clears
+  // connected and no storage op is issued once busy clears
   get suspended() {
     return this.suspendSignal !== null && this.suspendSignal.suspended
   }
 
-  _replicationBusy() {
+  get busy() {
     if (this._applyingReorg !== null) return true
     for (const peer of this.peers) {
       if (peer.receiverBusy || peer.dataProcessing > 0 || peer.syncsProcessing > 0) return true

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -1107,15 +1107,6 @@ class Peer {
 
       // sync from now on, so safe to delete from the map
       this.remoteRequests.delete(req.msg.id)
-
-      // suspended mid-flight, after async req.fulfill(). This request was
-      // already unregistered, so falling through to the isActive() below
-      // would drop it. Putting it back for the next _handleRequests() call.
-      if (this.replicator.suspended && !this.removed && proof.block !== null) {
-        this.remoteRequests.set(req.msg.id, req.msg)
-        this.receiverQueue.push(req.msg)
-        return
-      }
     } else if (!this.remoteAllowPush) {
       // if pushing but remote disabled it, just drop it
       return
@@ -1940,7 +1931,7 @@ class Peer {
   }
 
   isActive() {
-    if (this.paused || this.removed || this.replicator.suspended || this.core.header.frozen) {
+    if (this.paused || this.removed || this.core.header.frozen) {
       return false
     }
     return true
@@ -2858,9 +2849,7 @@ module.exports = class Replicator {
   }
 
   _onwant(peer, start, length, any) {
-    // wants are answered from memory, and dropping them while suspended
-    // would leave the remote blind to our ranges after resume
-    if (!peer.isActive() && !this.suspended) return
+    if (!peer.isActive()) return
 
     const contig = Math.min(this.core.state.length, this.core.header.hints.contiguousLength)
 
@@ -2992,7 +2981,7 @@ module.exports = class Replicator {
 
   _updateHotswap(peer) {
     const maxHotswaps = peer.getMaxHotswapInflight()
-    if (!peer.isActive() || peer.inflight >= maxHotswaps) return
+    if (!peer.isActive() || this.suspended || peer.inflight >= maxHotswaps) return
 
     for (const b of this.hotswaps.pick(peer)) {
       if (peer._requestBlock(b) === false) continue
@@ -3003,7 +2992,12 @@ module.exports = class Replicator {
   }
 
   _updatePeer(peer) {
-    if (!peer.isActive() || peer.inflight >= peer.getMaxInflight() || !peer.remoteUploading) {
+    if (
+      !peer.isActive() ||
+      this.suspended ||
+      peer.inflight >= peer.getMaxInflight() ||
+      !peer.remoteUploading
+    ) {
       return false
     }
 
@@ -3039,7 +3033,12 @@ module.exports = class Replicator {
   }
 
   _updatePeerNonPrimary(peer) {
-    if (!peer.isActive() || peer.inflight >= peer.getMaxInflight() || !peer.remoteUploading) {
+    if (
+      !peer.isActive() ||
+      this.suspended ||
+      peer.inflight >= peer.getMaxInflight() ||
+      !peer.remoteUploading
+    ) {
       return false
     }
 

--- a/lib/suspend-controller.js
+++ b/lib/suspend-controller.js
@@ -1,0 +1,46 @@
+const { EventEmitter } = require('events')
+
+class SuspendSignal extends EventEmitter {
+  constructor() {
+    super()
+
+    this._suspended = false
+    this.setMaxListeners(0) // one listener per core
+  }
+
+  get suspended() {
+    return this._suspended
+  }
+}
+
+/**
+ * Controls replication suspension for one or more cores, like an
+ * AbortController. The owner holds the controller and passes its signal to
+ * cores via the `suspendSignal` option. While suspended, replication pauses
+ * both ways but peers stay connected, and a core opened while suspended
+ * comes up suspended. On resume, requests queued while suspended are served
+ * and dropped data is re-requested. A core without a signal never suspends.
+ */
+module.exports = class SuspendController {
+  static Signal = SuspendSignal
+
+  constructor() {
+    this.signal = new SuspendSignal()
+  }
+
+  get suspended() {
+    return this.signal.suspended
+  }
+
+  suspend() {
+    if (this.signal._suspended) return
+    this.signal._suspended = true
+    this.signal.emit('suspend')
+  }
+
+  resume() {
+    if (!this.signal._suspended) return
+    this.signal._suspended = false
+    this.signal.emit('resume')
+  }
+}

--- a/test/all.js
+++ b/test/all.js
@@ -36,6 +36,7 @@ async function runTests() {
   await import('./sessions.js')
   await import('./snapshots.js')
   await import('./streams.js')
+  await import('./suspend-replication.js')
   await import('./timeouts.js')
   await import('./user-data.js')
   await import('./wants.js')

--- a/test/suspend-replication.js
+++ b/test/suspend-replication.js
@@ -2,6 +2,7 @@ const test = require('brittle')
 const CoreStorage = require('hypercore-storage')
 const { create, replicate, eventFlush } = require('./helpers')
 const Hypercore = require('../')
+const { once } = require('events')
 
 test('suspended replication stops downloading, catches up on resume', async function (t) {
   const controller = new Hypercore.SuspendController()
@@ -47,6 +48,50 @@ test('suspended replication queues incoming requests, serves them on resume', as
   controller.resume()
 
   t.alike(await get, Buffer.from('c'), 'queued request served after resume')
+})
+
+test('suspended replication queues incoming requests, clear receiverBusy after handling w/ error', async function (t) {
+  const controller = new Hypercore.SuspendController()
+
+  const a = await create(t, null, { suspendSignal: controller.signal })
+  const b = await create(t, a.key)
+  await a.append(['a', 'b', 'c'])
+
+  const bAppended = once(b, 'append')
+  replicate(a, b, t)
+  await bAppended
+
+  controller.suspend()
+
+  // Artificial setup to right max invalid requests to force error when handling an invalid request
+  a.peers[0].stats.invalidRequests = 63
+
+  const peerForB = b.replicator.peers[0]
+  const invalidReq = {
+    peer: peerForB,
+    rt: 0,
+    id: 1,
+    fork: 0,
+    block: { index: 0, nodes: 2 },
+    hash: null,
+    seek: { bytes: 1, padding: 1 }, // invalid to both seek and block when upgrading
+    upgrade: { start: 0, length: 2 },
+    manifest: false,
+    priority: 1,
+    timestamp: 1754412092523,
+    elapsed: 0
+  }
+
+  b.replicator._inflight.add(invalidReq)
+  peerForB.wireRequest.send(invalidReq)
+
+  await eventFlush() // allow it to be sent
+
+  controller.resume()
+  t.ok(a.peers[0].receiverBusy, 'set to busy')
+  await eventFlush()
+
+  t.absent(a.peers[0].receiverBusy, 'no longer set to busy')
 })
 
 test('no storage io while replication and storage are suspended', async function (t) {

--- a/test/suspend-replication.js
+++ b/test/suspend-replication.js
@@ -50,6 +50,67 @@ test('suspended replication queues incoming requests, serves them on resume', as
   t.alike(await get, Buffer.from('c'), 'queued request served after resume')
 })
 
+test('suspended replication doesnt deadlock when suspended again mid-flight after resume', async function (t) {
+  const controller = new Hypercore.SuspendController()
+
+  const a = await create(t, null, { suspendSignal: controller.signal })
+  const b = await create(t, a.key)
+  await a.append(['a', 'b', 'c'])
+
+  const bAppended = once(b, 'append')
+  replicate(a, b, t)
+  await bAppended
+
+  controller.suspend()
+  const get = b.get(0)
+  const early = await Promise.race([get.then(() => 'served'), sleep(300).then(() => 'pending')])
+  t.is(early, 'pending', 'request not served while suspended')
+
+  // land the flutter suspend deterministically inside _fulfillRequest's one
+  // pending await, instead of guessing how many ticks req.fulfill() takes
+  const fired = fulfillMidflightSuspend(a.peers[0], controller)
+
+  controller.resume()
+  await fired
+  await eventFlush()
+  controller.resume()
+
+  t.alike(await get, Buffer.from('a'), 'queued request served after resume, not dropped')
+})
+
+test('suspended-again request is served exactly once, not duplicated', async function (t) {
+  const controller = new Hypercore.SuspendController()
+
+  const a = await create(t, null, { suspendSignal: controller.signal })
+  const b = await create(t, a.key)
+  await a.append(['a'])
+
+  const bAppended = once(b, 'append')
+  replicate(a, b, t)
+  await bAppended
+
+  controller.suspend()
+  const get = b.get(0)
+  await eventFlush()
+
+  const fired = fulfillMidflightSuspend(a.peers[0], controller)
+
+  controller.resume()
+  await fired
+  await eventFlush()
+
+  const wireDataTxBefore = a.replicator.stats.wireData.tx
+  controller.resume()
+
+  t.alike(await get, Buffer.from('a'))
+  await eventFlush()
+  t.is(
+    a.replicator.stats.wireData.tx,
+    wireDataTxBefore + 1,
+    'served exactly once, no duplicate send'
+  )
+})
+
 test('suspended replication queues incoming requests, clear receiverBusy after handling w/ error', async function (t) {
   const controller = new Hypercore.SuspendController()
 
@@ -183,6 +244,27 @@ test('core push while suspending', async function (t) {
   t.absent(await b.has(0), 'block still absent')
   t.is(a.replicator.stats.wireData.tx, wireDataTxBefore, 'block not sent because !isActive()')
 })
+
+// patches peer._fulfillRequest for exactly one call, firing controller.suspend()
+// synchronously right after it starts (while its one internal await is pending)
+// so the flutter lands inside the race window instead of at a guessed tick count
+function fulfillMidflightSuspend(peer, controller) {
+  const orig = peer._fulfillRequest.bind(peer)
+  let resolve
+  const fired = new Promise((r) => {
+    resolve = r
+  })
+
+  peer._fulfillRequest = function (req, pushing) {
+    peer._fulfillRequest = orig
+    const p = orig(req, pushing)
+    controller.suspend()
+    resolve()
+    return p
+  }
+
+  return fired
+}
 
 async function drainReplication(core) {
   while (core.core.replicator.busy) await sleep(10)

--- a/test/suspend-replication.js
+++ b/test/suspend-replication.js
@@ -104,7 +104,7 @@ test('core opened while the signal is suspended is born suspended', async functi
 })
 
 async function drainReplication(core) {
-  while (core.core.replicator._replicationBusy()) await sleep(10)
+  while (core.core.replicator.busy) await sleep(10)
 }
 
 function sleep(ms) {

--- a/test/suspend-replication.js
+++ b/test/suspend-replication.js
@@ -32,18 +32,22 @@ test('suspended replication stops downloading, catches up on resume', async func
 
 test('suspended replication queues incoming requests, serves them on resume', async function (t) {
   const controller = new Hypercore.SuspendController()
-  controller.suspend()
 
   const a = await create(t, null, { suspendSignal: controller.signal })
+  const b = await create(t, a.key)
   await a.append(['a', 'b', 'c'])
 
-  const b = await create(t, a.key)
-
+  // sync before suspending
+  const bAppended = once(b, 'append')
   replicate(a, b, t)
+  await bAppended
+
+  controller.suspend()
 
   const get = b.get(2)
   const early = await Promise.race([get.then(() => 'served'), sleep(300).then(() => 'pending')])
   t.is(early, 'pending', 'request not served while suspended')
+  t.is(a.peers[0].receiverQueue.length, 1, 'request queued while suspended')
 
   controller.resume()
 

--- a/test/suspend-replication.js
+++ b/test/suspend-replication.js
@@ -151,7 +151,7 @@ test('core opened while the signal is suspended is born suspended', async functi
 test('core push while suspending', async function (t) {
   const controller = new Hypercore.SuspendController()
 
-  const a = await create(t, null, { suspendSignal: controller.signal  })
+  const a = await create(t, null, { suspendSignal: controller.signal })
   const b = await create(t, a.key, { allowPush: true, pushOnly: true })
 
   b.replicator.setPushOnly(true)

--- a/test/suspend-replication.js
+++ b/test/suspend-replication.js
@@ -103,6 +103,42 @@ test('core opened while the signal is suspended is born suspended', async functi
   t.alike(await get, Buffer.from('b'), 'served after the shared signal resumed')
 })
 
+test('core push while suspending', async function (t) {
+  const controller = new Hypercore.SuspendController()
+
+  const a = await create(t, null, { suspendSignal: controller.signal  })
+  const b = await create(t, a.key, { allowPush: true, pushOnly: true })
+
+  b.replicator.setPushOnly(true)
+  t.is(b.replicator.pushOnly, true, 'b is push only')
+
+  replicate(a, b, t)
+
+  await a.append(['a', 'b', 'c'])
+
+  t.ok(a.peers[0].remoteAllowPush, 'a sees b as push only')
+  t.is(a.peers[0].pushProcessing, 0, 'a sees b w/ no pushes initially')
+  t.absent(a.replicator.busy, 'isnt busy initially')
+
+  const wireDataTxBefore = a.replicator.stats.wireData.tx
+
+  const pushP = a.replicator.push(0)
+  t.absent(a.replicator.suspended, 'isnt suspended yet')
+  controller.suspend()
+
+  await eventFlush()
+  t.ok(a.replicator.busy, 'pushing makes replicator busy')
+  t.ok(a.replicator.suspended, 'now suspended')
+  t.is(a.peers[0].pushProcessing, 1, 'a sees b w/ a push')
+  await pushP
+
+  t.absent(await b.has(0), 'b doesnt have block')
+  controller.resume()
+
+  t.absent(await b.has(0), 'block still absent')
+  t.is(a.replicator.stats.wireData.tx, wireDataTxBefore, 'block not sent because !isActive()')
+})
+
 async function drainReplication(core) {
   while (core.core.replicator.busy) await sleep(10)
 }

--- a/test/suspend-replication.js
+++ b/test/suspend-replication.js
@@ -1,0 +1,112 @@
+const test = require('brittle')
+const CoreStorage = require('hypercore-storage')
+const { create, replicate, eventFlush } = require('./helpers')
+const Hypercore = require('../')
+
+test('suspended replication stops downloading, catches up on resume', async function (t) {
+  const controller = new Hypercore.SuspendController()
+
+  const a = await create(t)
+  await a.append(['a', 'b', 'c'])
+
+  const b = await create(t, a.key, { suspendSignal: controller.signal })
+
+  replicate(a, b, t)
+
+  await b.get(0)
+
+  controller.suspend()
+  await drainReplication(b)
+
+  await a.append(['d', 'e'])
+  await eventFlush()
+  await sleep(200)
+
+  t.is(b.length, 3, 'no upgrade while suspended')
+
+  controller.resume()
+
+  t.alike(await b.get(4), Buffer.from('e'), 'caught up after resume')
+})
+
+test('suspended replication queues incoming requests, serves them on resume', async function (t) {
+  const controller = new Hypercore.SuspendController()
+  controller.suspend()
+
+  const a = await create(t, null, { suspendSignal: controller.signal })
+  await a.append(['a', 'b', 'c'])
+
+  const b = await create(t, a.key)
+
+  replicate(a, b, t)
+
+  const get = b.get(2)
+  const early = await Promise.race([get.then(() => 'served'), sleep(300).then(() => 'pending')])
+  t.is(early, 'pending', 'request not served while suspended')
+
+  controller.resume()
+
+  t.alike(await get, Buffer.from('c'), 'queued request served after resume')
+})
+
+test('no storage io while replication and storage are suspended', async function (t) {
+  const controller = new Hypercore.SuspendController()
+
+  const dir = await t.tmp()
+  const db = new CoreStorage(dir)
+
+  const a = new Hypercore(db, null, { suspendSignal: controller.signal })
+  await a.ready()
+  t.teardown(() => a.close())
+
+  await a.append(['a', 'b', 'c', 'd', 'e'])
+
+  const b = await create(t, a.key)
+
+  replicate(a, b, t)
+  await b.get(0)
+
+  controller.suspend()
+  await drainReplication(a)
+  await db.suspend()
+
+  // incoming request while fully suspended must queue, not park on storage
+  const get = b.get(3)
+  await eventFlush()
+  await sleep(300)
+
+  t.is(db.rocks.diagnostics().io, 0, 'no parked storage io while suspended')
+
+  await db.resume()
+  controller.resume()
+
+  t.alike(await get, Buffer.from('d'), 'served after resume')
+})
+
+test('core opened while the signal is suspended is born suspended', async function (t) {
+  const controller = new Hypercore.SuspendController()
+  controller.suspend()
+
+  const a = await create(t, null, { suspendSignal: controller.signal })
+  await a.append(['a', 'b', 'c'])
+
+  const b = await create(t, a.key)
+
+  replicate(a, b, t)
+
+  const get = b.get(1)
+  const early = await Promise.race([get.then(() => 'served'), sleep(300).then(() => 'pending')])
+  t.is(early, 'pending', 'core born suspended serves nothing')
+
+  controller.resume()
+
+  t.alike(await get, Buffer.from('b'), 'served after the shared signal resumed')
+})
+
+async function drainReplication(core) {
+  while (core.core.replicator._replicationBusy()) await sleep(10)
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}

--- a/test/suspend-replication.js
+++ b/test/suspend-replication.js
@@ -76,10 +76,8 @@ test('suspended replication doesnt deadlock when suspended again mid-flight afte
 
   controller.resume()
   await fired
-  await eventFlush()
-  controller.resume()
 
-  t.alike(await get, Buffer.from('a'), 'queued request served after resume, not dropped')
+  t.alike(await get, Buffer.from('a'), 'served once its in-flight read completed')
 })
 
 test('suspended-again request is served exactly once, not duplicated', async function (t) {
@@ -97,17 +95,20 @@ test('suspended-again request is served exactly once, not duplicated', async fun
   const get = b.get(0)
   await eventFlush()
 
+  const wireDataTxBefore = a.replicator.stats.wireData.tx
   const fired = fulfillMidflightSuspend(a.peers[0], controller)
 
   controller.resume()
   await fired
-  await eventFlush()
 
-  const wireDataTxBefore = a.replicator.stats.wireData.tx
+  t.alike(await get, Buffer.from('a'), 'served once its in-flight read completed')
+
+  // suspending again after it was sent
+  controller.suspend()
+  // resume to check for duplicate sends
   controller.resume()
-
-  t.alike(await get, Buffer.from('a'))
   await eventFlush()
+
   t.is(
     a.replicator.stats.wireData.tx,
     wireDataTxBefore + 1,
@@ -217,14 +218,18 @@ test('core push while suspending', async function (t) {
   const controller = new Hypercore.SuspendController()
 
   const a = await create(t, null, { suspendSignal: controller.signal })
-  const b = await create(t, a.key, { allowPush: true, pushOnly: true })
+  const b = await create(t, a.key, { allowPush: true })
+
+  await a.append(['a', 'b', 'c'])
+
+  replicate(a, b, t)
+  await b.get(2) // fully synced before switching to push-only
 
   b.replicator.setPushOnly(true)
   t.is(b.replicator.pushOnly, true, 'b is push only')
 
-  replicate(a, b, t)
-
-  await a.append(['a', 'b', 'c'])
+  await a.append(['d'])
+  await eventFlush()
 
   t.ok(a.peers[0].remoteAllowPush, 'a sees b as push only')
   t.is(a.peers[0].pushProcessing, 0, 'a sees b w/ no pushes initially')
@@ -232,21 +237,44 @@ test('core push while suspending', async function (t) {
 
   const wireDataTxBefore = a.replicator.stats.wireData.tx
 
-  const pushP = a.replicator.push(0)
+  const fired = fulfillMidflightSuspend(a.peers[0], controller)
+  const pushP = a.replicator.push(3)
   t.absent(a.replicator.suspended, 'isnt suspended yet')
-  controller.suspend()
 
-  await eventFlush()
+  await fired
   t.ok(a.replicator.busy, 'pushing makes replicator busy')
-  t.ok(a.replicator.suspended, 'now suspended')
+  t.ok(a.replicator.suspended, 'now suspended mid push')
   t.is(a.peers[0].pushProcessing, 1, 'a sees b w/ a push')
   await pushP
 
-  t.absent(await b.has(0), 'b doesnt have block')
-  controller.resume()
+  await waitForBlock(b, 3)
+  t.ok(await b.has(3), 'block sent despite suspend, its read was already in flight')
+  t.is(
+    a.replicator.stats.wireData.tx,
+    wireDataTxBefore + 1,
+    'in-flight push send goes through once its read completes'
+  )
 
-  t.absent(await b.has(0), 'block still absent')
-  t.is(a.replicator.stats.wireData.tx, wireDataTxBefore, 'block not sent because !isActive()')
+  // post-suspend so pushes should not read or send
+  await a.append(['e'])
+  await eventFlush()
+
+  const wireDataTxAfterFirst = a.replicator.stats.wireData.tx
+  await a.replicator.push(4)
+
+  t.is(a.peers[0].pushProcessing, 0, 'push started while suspended never begins reading')
+  t.absent(await b.has(4), 'no push while suspended')
+  t.is(
+    a.replicator.stats.wireData.tx,
+    wireDataTxAfterFirst,
+    'no send for a push that started while suspended'
+  )
+
+  controller.resume()
+  await a.replicator.push(4)
+
+  await waitForBlock(b, 4)
+  t.ok(await b.has(4), 'push works again after resume')
 })
 
 // patches peer._fulfillRequest for exactly one call, firing controller.suspend()
@@ -272,6 +300,10 @@ function fulfillMidflightSuspend(peer, controller) {
 
 async function drainReplication(core) {
   while (core.core.replicator.busy) await sleep(10)
+}
+
+async function waitForBlock(core, index) {
+  while (!(await core.has(index))) await sleep(10)
 }
 
 function sleep(ms) {


### PR DESCRIPTION
This adds a way to pause replication without dropping connections. `SuspendController` works like an `AbortController`: you hold the controller and pass `controller.signal` into cores via the new `suspendSignal` option. One signal can be shared by any number of cores, and a core opened while the signal is suspended comes up suspended.

While suspended, a core sends no requests, uploads no blocks and drops incoming data (clearing the request so it gets re-fetched later). Incoming requests are queued in the existing receiver queue and answered on resume, and the replicator listens for the signal's resume event to serve that backlog and re-request whatever was dropped. Wants are still answered since they're served from memory. `replicator._replicationBusy()` lets the caller wait until in-flight serves/verifies have finished after suspending.

The reason we need this: consumers can briefly suspend hypercore to release resources and locks, for example suspending the underlying storage, whilst keeping the swarm and peers warm. Without it, any replication traffic against suspended storage parks forever, so the only safe option today is tearing connections down first. With this, storage can suspend underneath live connections and everything picks up where it left off on resume, no reconnect needed.

Cores that don't pass a signal are completely unaffected.