### PR TITLE
Fix replication crash nil tree node

### DIFF
--- a/index.js
+++ b/index.js
@@ -362,7 +362,6 @@ class Hypercore extends EventEmitter {
   _autoRecover() {
     const recoverTreeNodeFromPeersBound = this.recoverTreeNodeFromPeers.bind(this)
     this.once('repaired', () => {
-      console.log('repaired')
       this.off('peer-add', recoverTreeNodeFromPeersBound)
     })
     this.on('peer-add', recoverTreeNodeFromPeersBound)

--- a/index.js
+++ b/index.js
@@ -351,18 +351,21 @@ class Hypercore extends EventEmitter {
     }
 
     // Setup automatic recovery if in repair mode
-    if (this.core._repairMode) {
-      const recoverTreeNodeFromPeersBound = this.recoverTreeNodeFromPeers.bind(this)
-      this.once('repaired', () => {
-        this.off('peer-add', recoverTreeNodeFromPeersBound)
-      })
-      this.on('peer-add', recoverTreeNodeFromPeersBound)
-    }
+    if (this.core._repairMode) this._autoRecover()
 
     this.emit('ready')
 
     // if we are a weak session the core might have closed...
     if (this.core.closing) this.close().catch(safetyCatch)
+  }
+
+  _autoRecover() {
+    const recoverTreeNodeFromPeersBound = this.recoverTreeNodeFromPeers.bind(this)
+    this.once('repaired', () => {
+      console.log('repaired')
+      this.off('peer-add', recoverTreeNodeFromPeersBound)
+    })
+    this.on('peer-add', recoverTreeNodeFromPeersBound)
   }
 
   _removeSession() {

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -1071,6 +1071,15 @@ class Peer {
       batch.tryFlush()
 
       await this._fulfillRequest(req, false)
+    } catch (err) {
+      if (err.code !== 'INVALID_OPERATION') throw err
+
+      // Might recover from being in repairMode
+      this.core._repairMode = true
+      this.replicator.setPushOnly(true)
+      for (const session of this.core.allSessions()) {
+        session._autoRecover()
+      }
     } finally {
       if (locked) this.replicator._txLock.unlock()
     }

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -1074,12 +1074,8 @@ class Peer {
     } catch (err) {
       if (err.code !== 'INVALID_OPERATION') throw err
 
-      // Might recover from being in repairMode
-      this.core._repairMode = true
-      this.replicator.setPushOnly(true)
-      for (const session of this.core.allSessions()) {
-        session._autoRecover()
-      }
+      this.wireNoData.send({ request: msg.id, reason: NOT_AVAILABLE })
+      return
     } finally {
       if (locked) this.replicator._txLock.unlock()
     }

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -3284,6 +3284,73 @@ test('idle range completion restarts if ranges cancel during yield', async funct
   t.is(completed, cancelLength, 'all complete ranges resolved')
 })
 
+test('repairMode enabled with one bad tree node', async (t) => {
+  const createStore = await createStored(t)
+  const core = await createStore()
+  await core.ready()
+
+  await core.append('0')
+  await core.append('1')
+
+  const recoveryCore = await create(t, core.key)
+
+  const recoveryStreams = replicate(core, recoveryCore, t)
+
+  await recoveryCore.download({ start: 0, end: core.length }).done()
+
+  t.ok(await recoveryCore.has(0, core.length), 'recovery core is setup')
+  await unreplicate(recoveryStreams)
+
+  // Corrupt storage: remove tree node 1 (the root of the length-2 tree)
+  const storage = core.state.storage
+  const tx = storage.write()
+  tx.deleteTreeNode(1)
+  await tx.flush()
+
+  // Force tree cache to be clear (would otherwise return cached node)
+  core.core.storage.treeCache.clear()
+
+  const core2 = await create(t, core.key)
+  await core2.ready()
+
+  const streams = replicate(core, core2, t)
+
+  t.absent(core.core._repairMode, 'core isnt in repair mode initially')
+
+  // Test that original error triggers repair but still errors
+  const errorPath = t.test('error path')
+  errorPath.plan(3)
+  const req = core2.get(0, { timeout: 500 })
+
+  await new Promise((resolve) => setTimeout(resolve, 100))
+  errorPath.ok(core.core._repairMode, 'core is in repair mode from request')
+
+  const repaired = once(core, 'repaired')
+  replicate(core, recoveryCore, t)
+  await repaired
+
+  errorPath.ok(core.core._repairMode, 'still flagged as in repair mode')
+  req.catch(() => errorPath.pass('original request fails'))
+
+  await unreplicate(streams)
+  await errorPath
+
+  // Reopen so no longer in repair mode
+  await core.close()
+  const coreReconnect = await createStore()
+  await coreReconnect.ready()
+  t.teardown(() => coreReconnect.close())
+
+  t.alike(coreReconnect.key, core.key, 'sanity: keys match')
+
+  // Re-connect
+  const reconnected = once(coreReconnect, 'peer-add')
+  replicate(coreReconnect, core2, t)
+  await reconnected
+
+  t.ok(await core2.get(0), 'request works')
+})
+
 async function createAndDownload(t, core) {
   const b = await create(t, core.key)
   replicate(core, b, t, { teardown: false })

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -3331,7 +3331,11 @@ test('repairMode enabled with one bad tree node', async (t) => {
 
   await new Promise((resolve) => setTimeout(resolve, 300))
 
-  errorPath.is(core2.replicator.peers[0].stats.notAvailableBackoffs, 32, 'got nodata MAX_BACKOFFS times')
+  errorPath.is(
+    core2.replicator.peers[0].stats.notAvailableBackoffs,
+    32,
+    'got nodata MAX_BACKOFFS times'
+  )
   errorPath.ok(core2.replicator.peers[0].paused, 'peer is paused')
 
   req.catch(() => t.pass('req failed!'))

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -3284,10 +3284,8 @@ test('idle range completion restarts if ranges cancel during yield', async funct
   t.is(completed, cancelLength, 'all complete ranges resolved')
 })
 
-test('repairMode enabled with one bad tree node', async (t) => {
-  const createStore = await createStored(t)
-  const core = await createStore()
-  await core.ready()
+test('send nodata with bad tree node', async (t) => {
+  const core = await create(t)
 
   await core.append('0')
   await core.append('1')
@@ -3295,7 +3293,6 @@ test('repairMode enabled with one bad tree node', async (t) => {
   await core.append('3')
 
   const core2 = await create(t, core.key)
-  await core2.ready()
 
   const core2Updated = once(core2, 'append')
   const streams = replicate(core, core2, t)

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -3291,64 +3291,54 @@ test('repairMode enabled with one bad tree node', async (t) => {
 
   await core.append('0')
   await core.append('1')
+  await core.append('2')
+  await core.append('3')
 
-  const recoveryCore = await create(t, core.key)
+  const core2 = await create(t, core.key)
+  await core2.ready()
 
-  const recoveryStreams = replicate(core, recoveryCore, t)
+  const core2Updated = once(core2, 'append')
+  const streams = replicate(core, core2, t)
+  await core2Updated
 
-  await recoveryCore.download({ start: 0, end: core.length }).done()
+  t.is(core2.length, core.length, 'got metadata')
 
-  t.ok(await recoveryCore.has(0, core.length), 'recovery core is setup')
-  await unreplicate(recoveryStreams)
+  // Test that original error triggers repair but still errors
+  const errorPath = t.test('error path')
+  errorPath.plan(4)
 
   // Corrupt storage: remove tree node 1 (the root of the length-2 tree)
   const storage = core.state.storage
   const tx = storage.write()
-  tx.deleteTreeNode(1)
+  tx.deleteTreeNode(1) // root
+  tx.deleteTreeNode(2) // sibling node
   await tx.flush()
 
   // Force tree cache to be clear (would otherwise return cached node)
   core.core.storage.treeCache.clear()
 
-  const core2 = await create(t, core.key)
-  await core2.ready()
+  // Verify
+  {
+    const storage = core.state.storage
+    const rx = storage.read()
+    const treeP = rx.getTreeNode(1)
+    rx.tryFlush()
+    t.is(await treeP, null, 'corrupted correctly')
+  }
 
-  const streams = replicate(core, core2, t)
-
-  t.absent(core.core._repairMode, 'core isnt in repair mode initially')
-
-  // Test that original error triggers repair but still errors
-  const errorPath = t.test('error path')
-  errorPath.plan(3)
+  errorPath.is(core2.replicator.peers[0].stats.notAvailableBackoffs, 0, 'zero nodatas to start')
   const req = core2.get(0, { timeout: 500 })
 
-  await new Promise((resolve) => setTimeout(resolve, 100))
-  errorPath.ok(core.core._repairMode, 'core is in repair mode from request')
+  await new Promise((resolve) => setTimeout(resolve, 300))
 
-  const repaired = once(core, 'repaired')
-  replicate(core, recoveryCore, t)
-  await repaired
+  errorPath.is(core2.replicator.peers[0].stats.notAvailableBackoffs, 32, 'got nodata MAX_BACKOFFS times')
+  errorPath.ok(core2.replicator.peers[0].paused, 'peer is paused')
 
-  errorPath.ok(core.core._repairMode, 'still flagged as in repair mode')
-  req.catch(() => errorPath.pass('original request fails'))
+  req.catch(() => t.pass('req failed!'))
+  await errorPath.exception(() => req, 'original request fails')
 
   await unreplicate(streams)
   await errorPath
-
-  // Reopen so no longer in repair mode
-  await core.close()
-  const coreReconnect = await createStore()
-  await coreReconnect.ready()
-  t.teardown(() => coreReconnect.close())
-
-  t.alike(coreReconnect.key, core.key, 'sanity: keys match')
-
-  // Re-connect
-  const reconnected = once(coreReconnect, 'peer-add')
-  replicate(coreReconnect, core2, t)
-  await reconnected
-
-  t.ok(await core2.get(0), 'request works')
 })
 
 async function createAndDownload(t, core) {


### PR DESCRIPTION
When fulfilling a request, if there is a tree node corruption, it should fall back to repair mode so it can recover.

As with the other use of repair mode, the core needs to be restarted to fulfill requests again.

Refactored auto recovery from peers into a method for calling on sessions from replicator.

Made with help from AI.