### PR TITLE
Update remote contiguous length even not fullycontig

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,7 +657,7 @@ Populated after `ready` has been emitted. Will be `0` before the event.
 
 #### `core.remoteContiguousLength`
 
-How many blocks are contiguously available starting from the first block of this core on any known remote. This is only updated when a remote thinks it is fully contiguous such that they have all known blocks.
+How many blocks are contiguously available starting from the first block of this core on any known remote.
 
 Populated after `ready` has been emitted. Will be `0` before the event.
 

--- a/lib/replicator.js
+++ b/lib/replicator.js
@@ -496,7 +496,7 @@ class Peer {
     this.remotePublicKey = this.stream.remotePublicKey
     this.remoteSupportsSeeks = false
     this.inflightRange = inflightRange
-    this.fullyDownloadedSignaled = 0
+    this.contiguousLengthSignaled = 0
 
     this.paused = false
     this.removed = false
@@ -625,22 +625,28 @@ class Peer {
     if (drop) this._unclearLocalRange(start, length)
     else this._clearLocalRange(start, length)
 
-    const fullyContig = this.core.header.hints.contiguousLength === this.core.state.length
+    const contig = this.core.header.hints.contiguousLength
+    const fullyContig = contig === this.core.state.length
 
     if (start + LAST_BLOCKS < this.core.state.length && !drop && !fullyContig) {
       if (!this.remoteWants.hasRange(start, length)) return
     }
 
     let force = false
+
+    // Always force a broadcast when our own contiguous length grows, so the remote learns
+    // about it even if it already has this data itself (eg it's the original writer)
+    if (!drop && this.contiguousLengthSignaled < contig) {
+      this.contiguousLengthSignaled = contig
+      force = true
+    }
+
     if (fullyContig && !drop) {
       start = 0
       length = this.core.state.length
-
-      // Always send the broadcast when we switch from sparse to fully contiguous, so remote knows too
-      if (this.fullyDownloadedSignaled < length) {
-        this.fullyDownloadedSignaled = length
-        force = true
-      }
+    } else if (force) {
+      start = 0
+      length = contig
     }
 
     // TODO: consider also adding early-returns on the drop===true case
@@ -2175,7 +2181,7 @@ module.exports = class Replicator {
     }
 
     for (const peer of this.peers) {
-      peer.fullyDownloadedSignaled = Math.min(newLength, peer.fullyDownloadedSignaled)
+      peer.contiguousLengthSignaled = Math.min(newLength, peer.contiguousLengthSignaled)
       peer._unclearLocalRange(newLength, truncated)
     }
   }

--- a/test/remote-length.js
+++ b/test/remote-length.js
@@ -43,8 +43,8 @@ test('contiguous-length announce-on-update flow', async function (t) {
   )
   t.is(
     getPeer(a, b).remoteContiguousLength,
-    0,
-    'b did not notify peers he already knows own that block'
+    1,
+    'b notifies peers of its new contiguous length even if they already have that data'
   )
 })
 

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -2387,7 +2387,7 @@ test('remote contiguous length', async function (t) {
   t.is(a.remoteContiguousLength, 1)
 })
 
-test.solo('remote contiguous length', async function (t) {
+test.solo('remote contiguous length when partially downloaded', async function (t) {
   const a = await create(t)
   const b = await create(t, a.key)
 

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -2207,12 +2207,20 @@ test('range is broadcast when a core is fully available', async function (t) {
   replicate(writer, reader, t)
   await reader.get(0)
   t.is(writer.replicator.stats.wireRange.tx, 1, 'transmitted range when connection opened')
-  t.is(reader.replicator.stats.wireRange.tx, 0, 'reader did not transmit range yet')
+  t.is(
+    reader.replicator.stats.wireRange.tx,
+    1,
+    'reader transmitted range as its contiguous length grew'
+  )
 
   await reader.get(1)
   await reader.get(2)
   t.is(reader.contiguousLength, 3, 'fully downloaded core (sanity check)')
-  t.is(reader.replicator.stats.wireRange.tx, 1, 'reader transmitted range when fully downloaded')
+  t.is(
+    reader.replicator.stats.wireRange.tx,
+    3,
+    'reader transmitted range for each contiguous length increase'
+  )
   t.is(writer.replicator.stats.wireRange.tx, 1, 'writer sent no new messages')
 
   await writer.append(['d', 'e'])
@@ -2224,14 +2232,18 @@ test('range is broadcast when a core is fully available', async function (t) {
 
   await reader.get(3)
   t.is(reader.contiguousLength, 4, 'not fully downloaded (sanity check)')
-  t.is(reader.replicator.stats.wireRange.tx, 1, 'no new broadcast range since not fully downloaded')
+  t.is(
+    reader.replicator.stats.wireRange.tx,
+    4,
+    'broadcast sent since contiguous length increased, even though not fully downloaded'
+  )
 
   await reader.get(4)
   t.is(reader.contiguousLength, 5, 'fully downloaded (sanity check)')
   t.is(
     reader.replicator.stats.wireRange.tx,
-    2,
-    'new broadcast range since it is again fully downloaded'
+    5,
+    'new broadcast range since contiguous length increased again'
   )
 
   await writer.clear(1, 2)
@@ -2286,13 +2298,13 @@ test('range is broadcast when a core is fully available (multiple peers)', async
 
   t.is(
     writerToReader1.remoteContiguousLength,
-    0,
-    'reader1 skipped range update to writer (not contig yet)'
+    1,
+    'reader1 sent range update to writer for its partial contiguous length'
   )
   t.is(
     writerToReader2.remoteContiguousLength,
-    0,
-    'reader2 skipped range update to writer (not contig yet)'
+    1,
+    'reader2 sent range update to writer for its partial contiguous length'
   )
   t.is(reader1ToWriter.remoteContiguousLength, 3, 'writer updated for reader1')
   t.is(reader2ToWriter.remoteContiguousLength, 3, 'writer updated for reader2')
@@ -2415,8 +2427,8 @@ test('remote contiguous length when partially downloaded', async function (t) {
   t.is(a.peers[0].remoteContiguousLength, 2, 'peer remote contig')
 })
 
-test('remote contiguous length - fully contiguous only', async function (t) {
-  t.plan(7)
+test('remote contiguous length - updates incrementally, not just when fully contiguous', async function (t) {
+  t.plan(8)
   const a = await create(t)
   const b = await create(t, a.key)
 
@@ -2427,8 +2439,9 @@ test('remote contiguous length - fully contiguous only', async function (t) {
 
   t.is(a.remoteContiguousLength, 0)
 
+  let expected = 1
   a.on('remote-contiguous-length', (length) => {
-    t.is(length, 2, '`remote-contiguous-length` event fired')
+    t.is(length, expected++, '`remote-contiguous-length` event fired')
   })
 
   replicate(a, b, t)
@@ -2437,7 +2450,7 @@ test('remote contiguous length - fully contiguous only', async function (t) {
 
   await eventFlush()
 
-  t.is(a.remoteContiguousLength, 0, 'remoteContiguousLength didnt update')
+  t.is(a.remoteContiguousLength, 1, 'remoteContiguousLength updates on partial download')
   t.is(b.contiguousLength, 1, 'b has 1st block')
 
   await b.get(1)

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -2387,6 +2387,34 @@ test('remote contiguous length', async function (t) {
   t.is(a.remoteContiguousLength, 1)
 })
 
+test.solo('remote contiguous length', async function (t) {
+  const a = await create(t)
+  const b = await create(t, a.key)
+
+  t.is(a.remoteContiguousLength, 0)
+
+  await a.append(['a'])
+  await a.append(['b'])
+
+  t.is(a.remoteContiguousLength, 0, 'sanity check')
+
+  replicate(a, b, t)
+
+  await b.get(0)
+  await new Promise(resolve =>setTimeout(resolve, 250))
+
+  t.is(b.contiguousLength, 1, 'sanity check')
+  t.is(a.remoteContiguousLength, 1)
+  t.is(a.peers[0].remoteContiguousLength, 1)
+
+  await b.get(1)
+  await new Promise(resolve =>setTimeout(resolve, 250))
+
+  t.is(b.contiguousLength, 2, 'sanity check')
+  t.is(a.remoteContiguousLength, 2)
+  t.is(a.peers[0].remoteContiguousLength, 2)
+})
+
 test('remote contiguous length - fully contiguous only', async function (t) {
   t.plan(7)
   const a = await create(t)

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -2391,8 +2391,6 @@ test.solo('remote contiguous length when partially downloaded', async function (
   const a = await create(t)
   const b = await create(t, a.key)
 
-  t.is(a.remoteContiguousLength, 0)
-
   await a.append(['a'])
   await a.append(['b'])
 

--- a/test/replicate.js
+++ b/test/replicate.js
@@ -2387,7 +2387,7 @@ test('remote contiguous length', async function (t) {
   t.is(a.remoteContiguousLength, 1)
 })
 
-test.solo('remote contiguous length when partially downloaded', async function (t) {
+test('remote contiguous length when partially downloaded', async function (t) {
   const a = await create(t)
   const b = await create(t, a.key)
 
@@ -2398,19 +2398,21 @@ test.solo('remote contiguous length when partially downloaded', async function (
 
   replicate(a, b, t)
 
+  const bBlock0 = once(a, 'remote-contiguous-length')
   await b.get(0)
-  await new Promise(resolve =>setTimeout(resolve, 250))
+  await bBlock0
 
   t.is(b.contiguousLength, 1, 'sanity check')
-  t.is(a.remoteContiguousLength, 1)
-  t.is(a.peers[0].remoteContiguousLength, 1)
+  t.is(a.remoteContiguousLength, 1, 'session remote contig')
+  t.is(a.peers[0].remoteContiguousLength, 1, 'peer remote contig')
 
+  const bBlock1 = once(a, 'remote-contiguous-length')
   await b.get(1)
-  await new Promise(resolve =>setTimeout(resolve, 250))
+  await bBlock1
 
   t.is(b.contiguousLength, 2, 'sanity check')
-  t.is(a.remoteContiguousLength, 2)
-  t.is(a.peers[0].remoteContiguousLength, 2)
+  t.is(a.remoteContiguousLength, 2, 'session remote contig')
+  t.is(a.peers[0].remoteContiguousLength, 2, 'peer remote contig')
 })
 
 test('remote contiguous length - fully contiguous only', async function (t) {


### PR DESCRIPTION
Builds on #857's test. This solution will break the documented behavior in favor of the more intuitive idea that `remote-contiguous-length` event will fire for all updates to the remote contig length, not just when it's fully contiguous.

Other methods will be explored so keeping draft for now.

This PR is AI assisted.